### PR TITLE
add terminal-based colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tuxedo
 
 A fast, keyboard-driven terminal UI for [todo.txt](http://todotxt.org/).
-Vim-style bindings, atomic writes, instant external-edit detection, and four
+Vim-style bindings, atomic writes, instant external-edit detection, and five
 hand-tuned themes — all in a single static binary.
 
 ```sh
@@ -26,7 +26,7 @@ brew install webstonehq/tap/tuxedo
 - **Sibling-file archive.** `A` moves completed tasks to `done.txt` next to your file, atomically.
 - **Filter, sort, multi-select.** Cycle by `+project` or `@context`, sort by priority / due / file order, and bulk-complete or bulk-delete in visual mode.
 - **Saved searches.** Name the active `/`-search with `fs`, then recall it any time by cycling saved filters with `ff`. Stored as plain `filter.<name>` lines in the config — hand-editable like everything else.
-- **Four themes, three densities.** Cycle with `T` and `D`. Choices persist across runs.
+- **Five themes, three densities.** Cycle with `T` and `D`. Choices persist across runs.
 - **No daemon, no database, no cloud.** One file in, one file out.
 
 ## Screens
@@ -50,7 +50,7 @@ brew install webstonehq/tap/tuxedo
 
 ## Themes
 
-`T` cycles through four built-in themes.
+`T` cycles through five built-in themes, including Terminal, which respects your terminal palette.
 
 | Muted Slate (default) | Dawn |
 | --- | --- |

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -167,7 +167,36 @@ pub const MATRIX: Theme = Theme {
     matched: rgb(0xff, 0xd6, 0x6e),
 };
 
-pub const BUILT_IN: &[&Theme] = &[&MUTED, &DAWN, &NORD, &MATRIX];
+pub const TERMINAL: Theme = Theme {
+    name: "Terminal",
+    bg: Color::Reset,
+    panel: Color::Reset,
+    border: Color::DarkGray,
+    fg: Color::Reset,
+    dim: Color::DarkGray,
+    accent: Color::Cyan,
+    cursor: Color::DarkGray,
+    selection: Color::DarkGray,
+    statusbar: Color::Reset,
+    status_fg: Color::Reset,
+    mode_fg: Color::Black,
+    mode_bg: Color::Cyan,
+    pri_a: Color::Red,
+    pri_b: Color::Yellow,
+    pri_c: Color::Green,
+    pri_d: Color::Blue,
+    pri_other: Color::Magenta,
+    project: Color::Green,
+    context: Color::Yellow,
+    due: Color::Yellow,
+    overdue: Color::Red,
+    today: Color::Red,
+    done: Color::DarkGray,
+    selected: Color::DarkGray,
+    matched: Color::Yellow,
+};
+
+pub const BUILT_IN: &[&Theme] = &[&MUTED, &DAWN, &NORD, &MATRIX, &TERMINAL];
 
 static REGISTRY: OnceLock<Vec<&'static Theme>> = OnceLock::new();
 
@@ -500,6 +529,15 @@ matched = #b58900
             std::process::id(),
             std::thread::current().id()
         ))
+    }
+
+    #[test]
+    fn terminal_theme_uses_terminal_palette() {
+        assert_eq!(TERMINAL.bg, Color::Reset);
+        assert_eq!(TERMINAL.panel, Color::Reset);
+        assert_eq!(TERMINAL.fg, Color::Reset);
+        assert_eq!(TERMINAL.pri_a, Color::Red);
+        assert_eq!(BUILT_IN.last().map(|t| t.name), Some("Terminal"));
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -537,7 +537,10 @@ matched = #b58900
         assert_eq!(TERMINAL.panel, Color::Reset);
         assert_eq!(TERMINAL.fg, Color::Reset);
         assert_eq!(TERMINAL.pri_a, Color::Red);
-        assert_eq!(BUILT_IN.last().map(|t| t.name), Some("Terminal"));
+        assert!(
+            BUILT_IN.iter().any(|t| t.name == TERMINAL.name),
+            "TERMINAL should be registered in BUILT_IN"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,8 +19,8 @@ pub mod logo;
 pub mod settings;
 pub mod share;
 pub mod status;
-pub mod theme_picker;
 pub mod task_row;
+pub mod theme_picker;
 
 // Pane and overlay sizing. Promoted out of inline literals so the three
 // `MIN_BODY_W` references below stay in sync, and so tweaking a sidebar

--- a/src/ui/theme_picker.rs
+++ b/src/ui/theme_picker.rs
@@ -30,11 +30,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let bg = Style::default().bg(theme.panel).fg(theme.fg);
 
-    let [list_area, footer_area] = Layout::vertical([
-        Constraint::Min(1),
-        Constraint::Length(1),
-    ])
-    .areas(inner);
+    let [list_area, footer_area] =
+        Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
 
     let cur = app.prefs.theme_idx();
 
@@ -58,7 +55,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                     Style::default()
                         .fg(theme.fg)
                         .bg(row_bg)
-                        .add_modifier(if is_sel { Modifier::BOLD } else { Modifier::empty() }),
+                        .add_modifier(if is_sel {
+                            Modifier::BOLD
+                        } else {
+                            Modifier::empty()
+                        }),
                 ),
             ])
             .style(Style::default().bg(row_bg))
@@ -71,23 +72,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         Span::raw("  "),
         Span::styled(
             "j/k",
-            Style::default()
-                .fg(theme.dim)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" navigate · ", Style::default().fg(theme.dim)),
         Span::styled(
             "Enter",
-            Style::default()
-                .fg(theme.dim)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" select · ", Style::default().fg(theme.dim)),
         Span::styled(
             "Esc",
-            Style::default()
-                .fg(theme.dim)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" cancel", Style::default().fg(theme.dim)),
     ])


### PR DESCRIPTION
This pull request adds a new built-in "Terminal" theme to the application, which uses your terminal's color palette. It updates the documentation and code to reflect the addition, and includes a test to ensure the new theme is set up correctly.

**Theme additions:**

* Added a new `TERMINAL` theme in `src/theme.rs`, which uses `Color::Reset` and other terminal palette colors for most elements, and appended it to the `BUILT_IN` themes list.
* Added a test to verify that the `TERMINAL` theme uses the terminal palette and is included as the last built-in theme.

**Documentation updates:**

* Updated `README.md` to mention five themes instead of four, and described the new Terminal theme. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53)