### PR TITLE
Live Theme Picker

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -50,4 +50,6 @@ pub enum Action {
     /// binds the HTTP server; subsequent invocations just re-show the
     /// overlay.
     OpenShare,
+    /// Open the theme picker dialog (j/k to preview, Enter to accept).
+    OpenThemePicker,
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{Receiver, TryRecvError};
 
 use crate::config::Config;
 use crate::serve::{self, ShareInfo};
-use crate::theme::Theme;
+use crate::theme::{self, Theme};
 use crate::todo::{self, Task};
 
 mod archive;
@@ -121,6 +121,9 @@ pub struct App {
     /// palette). Once bound, the entry stays for the rest of the
     /// session and the overlay just re-displays the saved QR.
     share: Option<ShareInfo>,
+    /// Theme index captured when the theme picker opened, so cancel
+    /// can restore it.
+    theme_pick_orig: usize,
 }
 
 impl App {
@@ -165,6 +168,7 @@ impl App {
             command_palette: CommandPaletteState::default(),
             view_scroll: [Cell::new(0), Cell::new(0)],
             share: None,
+            theme_pick_orig: 0,
         };
         app.recompute_visible();
         app
@@ -299,6 +303,45 @@ impl App {
         let msg = self.prefs.cycle_theme();
         self.flash(msg);
         self.save_prefs();
+    }
+
+    /// Enter theme picker mode. Snapshot the current theme index so
+    /// cancel can restore it. j/k live-previews; Enter accepts; Esc
+    /// reverts.
+    pub fn enter_pick_theme(&mut self) {
+        self.theme_pick_orig = self.prefs.theme_idx();
+        self.mode = Mode::PickTheme;
+    }
+
+    /// Step through themes in `forward` (true = next) direction with
+    /// wrap-around. The theme is applied immediately for live preview.
+    pub fn pick_theme_step(&mut self, forward: bool) {
+        let all = theme::all();
+        let len = all.len();
+        if len <= 1 {
+            return;
+        }
+        let cur = self.prefs.theme_idx();
+        let next = if forward {
+            (cur + 1) % len
+        } else {
+            (cur + len - 1) % len
+        };
+        self.prefs.set_theme_idx(next);
+    }
+
+    /// Accept the previewed theme and persist to config.
+    pub fn pick_theme_accept(&mut self) {
+        self.mode = Mode::Normal;
+        self.save_prefs();
+        self.flash(format!("theme: {}", self.theme().name));
+    }
+
+    /// Cancel the picker and restore the theme that was active when
+    /// the picker opened.
+    pub fn pick_theme_cancel(&mut self) {
+        self.prefs.set_theme_idx(self.theme_pick_orig);
+        self.mode = Mode::Normal;
     }
 
     pub fn cycle_density(&mut self) {

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -173,8 +173,13 @@ pub const ENTRIES: &[PaletteEntry] = &[
         action: Action::ToggleRightPane,
     },
     PaletteEntry {
-        label: "cycle theme",
+        label: "pick theme",
         keys: "T",
+        action: Action::OpenThemePicker,
+    },
+    PaletteEntry {
+        label: "cycle theme",
+        keys: "",
         action: Action::CycleTheme,
     },
     PaletteEntry {
@@ -514,6 +519,7 @@ mod tests {
             Action::CopyBody,
             Action::EscapeStack,
             Action::OpenShare,
+            Action::OpenThemePicker,
         ];
         for a in required {
             assert!(actions.contains(&a), "missing palette entry for {a:?}");

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -38,6 +38,9 @@ pub enum Mode {
     /// dismisses; press `s` again to re-open without rebinding (the
     /// server stays running once started).
     Share,
+    /// Theme picker dialog — j/k to preview themes, Enter to accept,
+    /// Esc to revert.
+    PickTheme,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             handle_prompt(app, key)
         }
         Mode::PickProject | Mode::PickContext | Mode::PickSavedFilter => handle_pick(app, key),
+        Mode::PickTheme => handle_pick_theme(app, key),
         Mode::CommandPalette => handle_command_palette(app, key),
         Mode::Share => handle_share(app, key),
         Mode::Normal | Mode::Visual => handle_normal(app, key),
@@ -484,6 +485,16 @@ fn handle_pick(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn handle_pick_theme(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => app.pick_theme_step(true),
+        KeyCode::Char('k') | KeyCode::Up => app.pick_theme_step(false),
+        KeyCode::Enter => app.pick_theme_accept(),
+        KeyCode::Esc => app.pick_theme_cancel(),
+        _ => {}
+    }
+}
+
 fn handle_command_palette(app: &mut App, key: KeyEvent) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     // List navigation. Plain j/k must type into the search box — the user
@@ -640,7 +651,7 @@ fn resolve_normal_key(app: &mut App, key: KeyEvent) -> Option<Action> {
         KeyCode::Char('+') => Action::BeginPromptProject,
         KeyCode::Char('[') => Action::ToggleLeftPane,
         KeyCode::Char(']') => Action::ToggleRightPane,
-        KeyCode::Char('T') => Action::CycleTheme,
+        KeyCode::Char('T') => Action::OpenThemePicker,
         KeyCode::Char('D') => Action::CycleDensity,
         KeyCode::Char('L') => Action::ToggleLineNum,
         KeyCode::Char('H') => Action::ToggleShowDone,
@@ -848,6 +859,13 @@ fn apply_action(app: &mut App, action: Action) {
             }
             Err(e) => app.flash(format!("share unavailable: {e}")),
         },
+        Action::OpenThemePicker => {
+            if theme::all().len() <= 1 {
+                app.flash("only one theme");
+            } else {
+                app.enter_pick_theme();
+            }
+        }
         Action::EscapeStack => {
             let has_pc = app.filter().project.is_some() || app.filter().context.is_some();
             let has_search = !app.filter().search.is_empty();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,6 +18,7 @@ pub mod logo;
 pub mod settings;
 pub mod share;
 pub mod status;
+pub mod theme_picker;
 pub mod task_row;
 
 // Pane and overlay sizing. Promoted out of inline literals so the three
@@ -147,6 +148,15 @@ pub fn draw(frame: &mut Frame, app: &App) {
             let r = centered_in(area, w, h);
             frame.render_widget(Clear, r);
             share::render(frame, r, app);
+        }
+        Mode::PickTheme => {
+            let h: u16 = area.height.saturating_sub(4).min(PALETTE_MAX_H);
+            let w: u16 = (u32::from(area.width) * 3 / 5)
+                .clamp(u32::from(PALETTE_MIN_W), u32::from(PALETTE_MAX_W))
+                as u16;
+            let r = centered_in(area, w, h);
+            frame.render_widget(Clear, r);
+            theme_picker::render(frame, r, app);
         }
         _ => {}
     }

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -24,6 +24,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         Mode::PromptSaveFilter => "SAVE FILTER".into(),
         Mode::CommandPalette => "COMMAND".into(),
         Mode::Share => "SHARE".into(),
+        Mode::PickTheme => "PICK THEME".into(),
     };
     if matches!(app.view, View::Archive) {
         mode_label = "ARCHIVE".into();

--- a/src/ui/theme_picker.rs
+++ b/src/ui/theme_picker.rs
@@ -1,0 +1,96 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::App;
+use crate::theme;
+
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let theme = app.theme();
+    let all = theme::all();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border).bg(theme.panel))
+        .title(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "tuxedo",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" · themes ", Style::default().fg(theme.dim)),
+        ]))
+        .style(Style::default().bg(theme.panel));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let bg = Style::default().bg(theme.panel).fg(theme.fg);
+
+    let [list_area, footer_area] = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
+
+    let cur = app.prefs.theme_idx();
+
+    let lines: Vec<Line> = all
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            let is_sel = i == cur;
+            let row_bg = if is_sel { theme.cursor } else { theme.panel };
+            let sigil_fg = if is_sel { theme.accent } else { row_bg };
+            Line::from(vec![
+                Span::styled(
+                    if is_sel { " ▶ " } else { "   " },
+                    Style::default()
+                        .fg(sigil_fg)
+                        .bg(row_bg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    t.name,
+                    Style::default()
+                        .fg(theme.fg)
+                        .bg(row_bg)
+                        .add_modifier(if is_sel { Modifier::BOLD } else { Modifier::empty() }),
+                ),
+            ])
+            .style(Style::default().bg(row_bg))
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines).style(bg), list_area);
+
+    let footer = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "j/k",
+            Style::default()
+                .fg(theme.dim)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" navigate · ", Style::default().fg(theme.dim)),
+        Span::styled(
+            "Enter",
+            Style::default()
+                .fg(theme.dim)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" select · ", Style::default().fg(theme.dim)),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(theme.dim)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" cancel", Style::default().fg(theme.dim)),
+    ])
+    .style(bg);
+    frame.render_widget(Paragraph::new(footer).style(bg), footer_area);
+}


### PR DESCRIPTION
## Summary

Adds a theme picker dialog (press `T`) that lists all available themes with live preview. the entire UI changes colors as you navigate through themes.

## Changes

- **`src/action.rs`** — added `OpenThemePicker` action
- **`src/app/types.rs`** — added `PickTheme` mode
- **`src/app/mod.rs`** — theme picker state + enter/step/accept/cancel methods
- **`src/ui/theme_picker.rs`** — new dialog renderer (title, theme list with ▶ cursor, navigation footer)
- **`src/ui/mod.rs`** — registered module + overlay rendering
- **`src/main.rs`** — changed `T` to open picker, `handle_pick_theme` handler
- **`src/app/palette.rs`** — "pick theme" palette entry
- **`src/ui/status.rs`** — added `PICK THEME` mode label

## Usage

- `T` opens the theme picker dialog
- `j`/`k` or `↑`/`↓` navigate themes with live preview
- `Enter` accepts the previewed theme and persists to config
- `Esc` reverts to the theme that was active before opening

`T` no longer cycles themes directly, use the picker instead. "Cycle theme" remains accessible from the command palette (`:` / `Ctrl-P`).

## A Quick Look

<img width="1918" height="1038" alt="image" src="https://github.com/user-attachments/assets/afd63e2a-612f-4ae1-a248-23b0956cc922" />