### PR TITLE
doc: add custom themes guide and Gruvbox Dark examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,61 @@ brew install webstonehq/tap/tuxedo
 
 ## Themes
 
-`T` cycles through five built-in themes, including Terminal, which respects your terminal palette.
+`T` opens a picker over five built-in themes, including Terminal, which respects your terminal palette.
 
 | Muted Slate (default) | Dawn |
 | --- | --- |
 | ![muted slate](docs/screenshots/theme-muted-slate.svg) | ![dawn](docs/screenshots/theme-dawn.svg) |
 | **Nord** | **Matrix** |
 | ![nord](docs/screenshots/theme-nord.svg) | ![matrix](docs/screenshots/theme-matrix.svg) |
+
+### Custom themes
+
+Beyond the built-ins, tuxedo loads any `*.toml` file you drop in
+`${XDG_CONFIG_HOME:-$HOME/.config}/tuxedo/themes/`. Each one joins the `T`
+picker in sorted filename order. Ready-made themes live in
+[`docs/themes/`](docs/themes) — copy one in and press `T`:
+
+```sh
+mkdir -p ~/.config/tuxedo/themes
+curl -o ~/.config/tuxedo/themes/gruvbox-dark-soft.toml \
+  https://raw.githubusercontent.com/webstonehq/tuxedo/main/docs/themes/gruvbox-dark-soft.toml
+```
+
+<details>
+<summary>Theme file format and field reference</summary>
+
+A theme file is one `key = value` per line. `name` is the label shown in the
+picker; every other field is a `#rrggbb` color. All fields are required: a file
+missing one, carrying an unparseable color, or whose `name` collides with
+another theme is skipped with a warning at startup.
+
+| Field | Colors |
+| --- | --- |
+| `name` | label shown in the `T` picker (the only non-color field) |
+| `bg` | window background |
+| `panel` | filter and detail panel background |
+| `border` | panel and modal borders |
+| `fg` | primary text |
+| `dim` | secondary / muted text |
+| `accent` | logo, headings, hints, and selection markers |
+| `cursor` | current row, and the highlighted row in the `T` picker |
+| `selection` | set to the same value as `selected` |
+| `statusbar` | status bar background |
+| `status_fg` | status bar text |
+| `mode_fg` / `mode_bg` | mode chip text / background |
+| `pri_a` `pri_b` `pri_c` `pri_d` | priorities A through D |
+| `pri_other` | priorities E through Z |
+| `project` | `+project` tags |
+| `context` | `@context` tags |
+| `due` | `due:` date |
+| `overdue` | past-due date |
+| `today` | date due today |
+| `done` | completed tasks |
+| `selected` | selected-row background (visual mode) and the active filter |
+| `matched` | search-match highlight |
+
+</details>
 
 ## Install
 
@@ -248,7 +296,7 @@ config-file flag; configure paths with the environment variables above.
 | --- | --- |
 | `[` | toggle filter sidebar |
 | `]` | toggle detail sidebar |
-| `T` | cycle theme |
+| `T` | open theme picker |
 | `D` | cycle density: compact → comfortable → cozy |
 | `L` | toggle line numbers |
 

--- a/docs/themes/gruvbox-dark-hard.toml
+++ b/docs/themes/gruvbox-dark-hard.toml
@@ -1,0 +1,28 @@
+# Gruvbox Dark (hard contrast) for tuxedo.
+# Copy into ${XDG_CONFIG_HOME:-$HOME/.config}/tuxedo/themes/ and press T to select it.
+name = Gruvbox Dark Hard
+bg = #1d2021
+panel = #282828
+border = #504945
+fg = #ebdbb2
+dim = #928374
+accent = #fabd2f
+cursor = #504945
+selection = #3c3836
+statusbar = #282828
+status_fg = #a89984
+mode_fg = #1d2021
+mode_bg = #fabd2f
+pri_a = #fb4934
+pri_b = #fabd2f
+pri_c = #b8bb26
+pri_d = #83a598
+pri_other = #d3869b
+project = #b8bb26
+context = #fe8019
+due = #fabd2f
+overdue = #fb4934
+today = #fb4934
+done = #928374
+selected = #3c3836
+matched = #8ec07c

--- a/docs/themes/gruvbox-dark-soft.toml
+++ b/docs/themes/gruvbox-dark-soft.toml
@@ -1,0 +1,28 @@
+# Gruvbox Dark (soft contrast) for tuxedo.
+# Copy into ${XDG_CONFIG_HOME:-$HOME/.config}/tuxedo/themes/ and press T to select it.
+name = Gruvbox Dark Soft
+bg = #32302f
+panel = #3c3836
+border = #504945
+fg = #ebdbb2
+dim = #928374
+accent = #fabd2f
+cursor = #504945
+selection = #3c3836
+statusbar = #3c3836
+status_fg = #a89984
+mode_fg = #32302f
+mode_bg = #fabd2f
+pri_a = #fb4934
+pri_b = #fabd2f
+pri_c = #b8bb26
+pri_d = #83a598
+pri_other = #d3869b
+project = #b8bb26
+context = #fe8019
+due = #fabd2f
+overdue = #fb4934
+today = #fb4934
+done = #928374
+selected = #3c3836
+matched = #8ec07c


### PR DESCRIPTION
Closes #16.

Adds a `docs/themes/` directory with two ready-to-copy Gruvbox Dark themes (soft and hard contrast) and documents custom themes in the README's Themes section: where files are loaded from (`~/.config/tuxedo/themes/`), a copy-in command, and the full field reference folded into a `<details>` toggle.

Also corrects the stale "`T` cycles theme" wording in the Themes section and the keybindings table. Since the theme picker landed, `T` opens it.

Docs only, no code. Happy to follow up with a separate PR promoting Gruvbox to a built-in (with screenshots) if you would want it shipped by default.
