### PR TITLE
add Enter as additional key to accept autosuggestion from list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,7 @@ fn handle_insert(app: &mut App, key: KeyEvent) {
     if app.autocomplete_visible() {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
-            KeyCode::Tab => {
+            KeyCode::Tab | KeyCode::Enter => {
                 app.autocomplete_accept();
                 return;
             }


### PR DESCRIPTION
This is just a personal preference, however, since accepting a calendar date is also mapped to Enter i think its consistent and does not interfere with the existing workflow