### PR TITLE
feat(theme): support reset/transparent keyword in TOML theme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,18 @@ curl -o ~/.config/tuxedo/themes/gruvbox-dark-soft.toml \
 <summary>Theme file format and field reference</summary>
 
 A theme file is one `key = value` per line. `name` is the label shown in the
-picker; every other field is a `#rrggbb` color. All fields are required: a file
+picker; every other field is a color value. All fields are required: a file
 missing one, carrying an unparseable color, or whose `name` collides with
 another theme is skipped with a warning at startup.
+
+**Color values** accept two forms:
+
+- `#rrggbb` — a solid hex color (case-insensitive).
+- `reset` or `transparent` — inherits the terminal emulator's own background
+  color. Useful for `bg`, `panel`, and `statusbar` when you want your
+  terminal's opacity, blur, or wallpaper to show through while keeping a
+  custom text palette. Both keywords are case-insensitive and behave
+  identically (same effect as the built-in **Terminal** theme).
 
 | Field | Colors |
 | --- | --- |

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -322,7 +322,7 @@ fn parse_theme(s: &str) -> Result<Theme, String> {
         if let Some(field) = match_color_field(k) {
             let color = parse_color(v).ok_or_else(|| {
                 format!(
-                    "line {}: field '{field}' has invalid color '{v}' (expected #rrggbb)",
+                    "line {}: field '{field}' has invalid color '{v}' (expected #rrggbb or reset/transparent)",
                     lineno + 1
                 )
             })?;
@@ -404,9 +404,12 @@ fn match_color_field(k: &str) -> Option<&'static str> {
     COLOR_FIELDS.iter().copied().find(|f| *f == k)
 }
 
-/// Parse `#rrggbb` (case-insensitive). Returns None for any other shape;
-/// callers turn that into a user-facing error referencing the field.
+/// Parse a color value. Accepts `#rrggbb` hex or the keywords `reset` /
+/// `transparent` (both map to `Color::Reset`, inheriting the terminal bg).
 fn parse_color(s: &str) -> Option<Color> {
+    if s.eq_ignore_ascii_case("reset") || s.eq_ignore_ascii_case("transparent") {
+        return Some(Color::Reset);
+    }
     let hex = s.strip_prefix('#')?;
     if hex.len() != 6 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
         return None;


### PR DESCRIPTION
## Problem

Custom themes (`.toml` files in `~/.config/tuxedo/themes/`) can only specify solid `#rrggbb` hex colors. There is no way to express `Color::Reset` — the value the built-in **Terminal** theme uses so that background cells inherit the terminal emulator's own background color (transparency, blur, opacity, wallpaper).

This makes it impossible to author a custom theme that combines a personal color palette with a transparent background — you have to choose one or the other.

## Solution

Extend `parse_color()` to accept two additional keywords alongside `#rrggbb`:

| Value | Maps to | Effect |
|---|---|---|
| `reset` | `Color::Reset` | inherits terminal background |
| `transparent` | `Color::Reset` | alias — same effect |

Both are case-insensitive. All 26 color fields accept them. Existing hex color themes are completely unaffected.

The error message for an invalid color is updated to mention the new accepted forms:

```
line 3: field 'bg' has invalid color 'whatever' (expected #rrggbb or reset/transparent)
```

## Usage

A theme that uses Tokyo Night's text palette but lets the terminal background show through:

```toml
name = Tokyo Night
bg          = transparent
panel       = transparent
statusbar   = transparent
border      = #29304a
fg          = #c0caf5
dim         = #565f89
accent      = #7aa2f7
cursor      = #283457
selection   = #283457
status_fg   = #a9b1d6
mode_fg     = #1a1b26
mode_bg     = #7aa2f7
pri_a       = #f7768e
pri_b       = #e0af68
pri_c       = #9ece6a
pri_d       = #7dcfff
pri_other   = #bb9af7
project     = #9ece6a
context     = #ff9e64
due         = #e0af68
overdue     = #f7768e
today       = #f7768e
done        = #565f89
selected    = #283457
matched     = #e0af68
```

Drop this in `~/.config/tuxedo/themes/tokyo-night.toml`, press `T`, and Tokyo Night appears with a fully transparent background — the terminal emulator's wallpaper, blur, or opacity effect shows through, exactly as it does with the built-in Terminal theme.

## Implementation

The change is a 4-line addition to `parse_color()` in `src/theme.rs`:

```rust
fn parse_color(s: &str) -> Option<Color> {
    if s.eq_ignore_ascii_case("reset") || s.eq_ignore_ascii_case("transparent") {
        return Some(Color::Reset);
    }
    // existing #rrggbb path unchanged
    let hex = s.strip_prefix('#')?;
    ...
}
```

`Color::Reset` is already used by the built-in Terminal theme in the same file, so no new dependency or abstraction is introduced.

## Notes

- `reset` is the canonical name (mirrors ratatui's `Color::Reset`); `transparent` is provided as an alias since that is the more intuitive term for end users writing theme files.
- Both keywords are case-insensitive, consistent with how color hex values are already handled.
- The `docs/themes/` example themes are unchanged — they use hex colors and continue to work as before.
