### PR TITLE
feat: add autocomplete and tab completion to project/context prompt dialogs

### DIFF
--- a/src/app/autocomplete.rs
+++ b/src/app/autocomplete.rs
@@ -1,6 +1,6 @@
 use super::App;
 use super::draft::prev_char_boundary;
-use super::types::AUTOCOMPLETE_CAP;
+use super::types::{AUTOCOMPLETE_CAP, Mode};
 use crate::todo::{self, Task, starts_with_iso_date, starts_with_priority};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +17,14 @@ pub struct ActiveToken<'a> {
     pub kind: TokenKind,
     pub prefix: &'a str,
     pub start: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AutocompleteTarget<'a> {
+    pub kind: TokenKind,
+    pub prefix: &'a str,
+    pub replace_start: usize,
+    pub replace_end: usize,
 }
 
 /// Find the autocomplete token at `cursor`. Walks back through non-whitespace
@@ -53,6 +61,45 @@ pub fn active_token(draft: &str, cursor: usize) -> Option<ActiveToken<'_>> {
 }
 
 impl App {
+    /// Retrieve the autocomplete target (token kind, prefix, and replacement range)
+    /// based on the current app mode.
+    pub fn autocomplete_target(&self) -> Option<AutocompleteTarget<'_>> {
+        match self.mode {
+            Mode::PromptProject | Mode::PromptContext => {
+                let kind = if self.mode == Mode::PromptProject {
+                    TokenKind::Project
+                } else {
+                    TokenKind::Context
+                };
+                let text = self.draft.text();
+                let cursor = self.draft.cursor().min(text.len());
+                Some(AutocompleteTarget {
+                    kind,
+                    prefix: &text[..cursor],
+                    replace_start: 0,
+                    replace_end: text.len(),
+                })
+            }
+            _ => {
+                let tok = active_token(self.draft.text(), self.draft.cursor())?;
+                let token_start = tok.start;
+                let after_sigil = &self.draft.text()[token_start + 1..];
+                let end_offset = after_sigil
+                    .char_indices()
+                    .find(|(_, c)| c.is_whitespace())
+                    .map(|(i, _)| i)
+                    .unwrap_or(after_sigil.len());
+                let end = token_start + 1 + end_offset;
+                Some(AutocompleteTarget {
+                    kind: tok.kind,
+                    prefix: tok.prefix,
+                    replace_start: token_start + 1,
+                    replace_end: end,
+                })
+            }
+        }
+    }
+
     /// Whether the autocomplete popup should render and consume keys. False
     /// when there's no active token, the corpus has no matches, or the user
     /// has explicitly dismissed the popup with Esc.
@@ -65,13 +112,13 @@ impl App {
     /// matching the prefix. Sorted prefix-matches-first then contains-only,
     /// each group alphabetical, capped at 8.
     pub fn autocomplete_matches(&self) -> Vec<&str> {
-        let Some(tok) = active_token(self.draft.text(), self.draft.cursor()) else {
+        let Some(target) = self.autocomplete_target() else {
             return Vec::new();
         };
-        let prefix_lc = tok.prefix.to_lowercase();
+        let prefix_lc = target.prefix.to_lowercase();
         let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
         for t in self.store.tasks() {
-            let source = match tok.kind {
+            let source = match target.kind {
                 TokenKind::Project => &t.projects,
                 TokenKind::Context => &t.contexts,
             };
@@ -121,7 +168,7 @@ impl App {
     /// the cursor (sigil to next whitespace), so accepting `work` while the
     /// cursor sits inside `+wor` produces `+work`, not `+workr`.
     pub fn autocomplete_accept(&mut self) {
-        let Some(tok) = active_token(self.draft.text(), self.draft.cursor()) else {
+        let Some(target) = self.autocomplete_target() else {
             return;
         };
         let matches = self.autocomplete_matches();
@@ -130,15 +177,7 @@ impl App {
         }
         let idx = self.draft.autocomplete_index().min(matches.len() - 1);
         let chosen = matches[idx].to_string();
-        let token_start = tok.start;
-        let after_sigil = &self.draft.text()[token_start + 1..];
-        let end_offset = after_sigil
-            .char_indices()
-            .find(|(_, c)| c.is_whitespace())
-            .map(|(i, _)| i)
-            .unwrap_or(after_sigil.len());
-        let end = token_start + 1 + end_offset;
-        self.draft.replace_token(token_start + 1, end, &chosen);
+        self.draft.replace_token(target.replace_start, target.replace_end, &chosen);
     }
 }
 
@@ -454,5 +493,29 @@ mod tests {
         app.autocomplete_step(true); // selected = 1 → "beta"
         app.autocomplete_accept();
         assert_eq!(app.draft.text(), "X +beta");
+    }
+
+    #[test]
+    fn autocomplete_prompt_project_mode() {
+        let mut app = build_app("a +work\nb +health\n");
+        app.mode = Mode::PromptProject;
+        app.draft_set("hea".into());
+        assert!(app.autocomplete_visible());
+        assert_eq!(app.autocomplete_matches(), vec!["health"]);
+
+        app.autocomplete_accept();
+        assert_eq!(app.draft.text(), "health");
+    }
+
+    #[test]
+    fn autocomplete_prompt_context_mode() {
+        let mut app = build_app("a @work\nb @health\n");
+        app.mode = Mode::PromptContext;
+        app.draft_set("wor".into());
+        assert!(app.autocomplete_visible());
+        assert_eq!(app.autocomplete_matches(), vec!["work"]);
+
+        app.autocomplete_accept();
+        assert_eq!(app.draft.text(), "work");
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod test_support;
 pub use crate::core::Archive;
 pub use crate::core::History;
 pub use crate::core::filter::{ListDueBucket, ordered_unique};
-pub use autocomplete::{ActiveToken, TokenKind, active_token};
+pub use autocomplete::{ActiveToken, AutocompleteTarget, TokenKind, active_token};
 pub use chord::Chord;
 pub use draft::{DraftCursor, DraftState};
 pub use draft_overlay::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,33 +351,16 @@ fn handle_insert(app: &mut App, key: KeyEvent) {
     // project/context). Esc with the popup open dismisses the popup but leaves
     // Insert mode intact; a second Esc cancels the add (handled below).
     if app.autocomplete_visible() {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
             KeyCode::Tab | KeyCode::Enter => {
                 app.autocomplete_accept();
                 return;
             }
-            KeyCode::Up => {
-                app.autocomplete_step(false);
-                return;
+            _ => {
+                if handle_autocomplete_keys(app, key) {
+                    return;
+                }
             }
-            KeyCode::Down => {
-                app.autocomplete_step(true);
-                return;
-            }
-            KeyCode::Char('n') if ctrl => {
-                app.autocomplete_step(true);
-                return;
-            }
-            KeyCode::Char('p') if ctrl => {
-                app.autocomplete_step(false);
-                return;
-            }
-            KeyCode::Esc => {
-                app.draft.suppress_autocomplete();
-                return;
-            }
-            _ => {}
         }
     }
 
@@ -605,7 +588,48 @@ fn handle_command_palette(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn handle_autocomplete_keys(app: &mut App, key: KeyEvent) -> bool {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Up => {
+            app.autocomplete_step(false);
+            true
+        }
+        KeyCode::Down => {
+            app.autocomplete_step(true);
+            true
+        }
+        KeyCode::Char('n') if ctrl => {
+            app.autocomplete_step(true);
+            true
+        }
+        KeyCode::Char('p') if ctrl => {
+            app.autocomplete_step(false);
+            true
+        }
+        KeyCode::Esc => {
+            app.draft.suppress_autocomplete();
+            true
+        }
+        _ => false,
+    }
+}
+
 fn handle_prompt(app: &mut App, key: KeyEvent) {
+    if app.autocomplete_visible() {
+        match key.code {
+            KeyCode::Tab => {
+                app.autocomplete_accept();
+                return;
+            }
+            _ => {
+                if handle_autocomplete_keys(app, key) {
+                    return;
+                }
+            }
+        }
+    }
+
     match key.code {
         KeyCode::Esc => {
             app.mode = Mode::Normal;

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::app::{
-    self, App, BuilderField, CalendarTarget, DraftOverlay, Mode, REC_UNIT_ORDER, TokenKind,
+    App, BuilderField, CalendarTarget, DraftOverlay, Mode, REC_UNIT_ORDER, TokenKind,
 };
 use crate::theme::Theme;
 
@@ -491,7 +491,7 @@ pub fn render_autocomplete(frame: &mut Frame, dlg: Rect, screen: Rect, app: &App
         return;
     }
     let theme = app.theme();
-    let kind = match app::active_token(app.draft.text(), app.draft.cursor()) {
+    let kind = match app.autocomplete_target() {
         Some(t) => t.kind,
         None => return,
     };
@@ -1481,6 +1481,83 @@ mod tests {
         assert!(
             !popup.contains("uniqueprojname"),
             "context popup must not list projects\n{popup}"
+        );
+    }
+
+    fn build_prompt_app(seed: &str, draft: &str, mode: Mode) -> App {
+        let path = std::env::temp_dir().join(format!(
+            "tuxedo-prompt-dialog-test-{}-{}.txt",
+            std::process::id(),
+            seed.len(),
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut app = App::new(
+            path,
+            seed.to_string(),
+            "2026-05-06".to_string(),
+            Config::default(),
+        );
+        app.mode = mode;
+        app.draft_set(draft.to_string());
+        app
+    }
+
+    fn prompt_popup_region_text(buf: &Buffer) -> String {
+        let rows = buf.area.height;
+        let cols = buf.area.width;
+        let dlg_h: u16 = 5; // PROMPT_H
+        let dlg_y = (rows.saturating_sub(dlg_h)) / 2;
+        let popup_top = dlg_y + dlg_h;
+        let popup_bottom = (popup_top + 8).min(rows);
+        let mut out = String::new();
+        for y in popup_top..popup_bottom {
+            for x in 0..cols {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn prompt_autocomplete_popup_renders_project_matches() {
+        let app = build_prompt_app(
+            "(A) 2026-05-01 a +work\n(A) 2026-05-01 b +health\n",
+            "hea",
+            Mode::PromptProject,
+        );
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &app)).unwrap();
+        let popup = prompt_popup_region_text(terminal.backend().buffer());
+        assert!(
+            popup.contains("health"),
+            "expected 'health' in popup\n{popup}"
+        );
+        assert!(
+            !popup.contains("work"),
+            "expected 'work' not to be in popup (doesn't match 'hea')\n{popup}"
+        );
+    }
+
+    #[test]
+    fn prompt_autocomplete_popup_renders_context_matches() {
+        let app = build_prompt_app(
+            "(A) 2026-05-01 a @work\n(A) 2026-05-01 b @health\n",
+            "hea",
+            Mode::PromptContext,
+        );
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::ui::draw(f, &app)).unwrap();
+        let popup = prompt_popup_region_text(terminal.backend().buffer());
+        assert!(
+            popup.contains("health"),
+            "expected 'health' in popup\n{popup}"
+        );
+        assert!(
+            !popup.contains("work"),
+            "expected 'work' not to be in popup (doesn't match 'hea')\n{popup}"
         );
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -135,6 +135,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
             let r = centered_in(area, w, PROMPT_H);
             frame.render_widget(Clear, r);
             dialog::render_prompt(frame, r, app);
+            if matches!(app.mode, Mode::PromptProject | Mode::PromptContext) {
+                dialog::render_autocomplete(frame, r, area, app);
+            }
         }
         Mode::CommandPalette => {
             let h: u16 = area.height.saturating_sub(4).min(PALETTE_MAX_H);


### PR DESCRIPTION
Solves Issue: #26 in a patterned way with the existing Autocomplete logic.

## Summary
This PR implements autocomplete suggestions and tab completion for the **`+` (Add Project)** and **`@` (Toggle Context)** prompt dialogs. 

Previously, typing a project or context name in these prompts required the user to enter the full name exactly. If they mistyped, a new project or context was created. With this change, matching projects/contexts from the user's task history are suggested in a dropdown, and can be completed using the **`Tab`** key.

---

## Key Changes

### 1. Autocomplete Engine Updates (`src/app/autocomplete.rs`, `src/app/mod.rs`)
* Introduced a unified `AutocompleteTarget` struct and helper method (`App::autocomplete_target`) to resolve autocomplete details (token kind, prefix, replacement range) regardless of whether the app is in the inline task insertion mode or prompt mode.

### 2. Event Handling (`src/main.rs`)
* Extracted shared key navigation and dismissal logic (`Up`, `Down`, `Ctrl-n`, `Ctrl-p`, `Esc`) into a helper function `handle_autocomplete_keys` to reduce duplication.
* Updated `handle_prompt` to check if the autocomplete dropdown is visible, allowing `Tab` to insert the suggestion, and standard navigation keys to move the selector. `Enter` continues to submit the current text box content immediately.

### 3. Dialog & UI Rendering (`src/ui/mod.rs`, `src/ui/dialog.rs`)
* Modified `dialog::render_autocomplete` to render directly under the prompt dialog box when in `PromptProject` or `PromptContext` modes.
* Simplified token kind resolving inside `render_autocomplete` to use the new `App::autocomplete_target` helper.

---

## Test Coverage

### Automated Tests
* Added unit tests to `src/app/autocomplete.rs` verifying matches and acceptance in both `PromptProject` and `PromptContext` modes.
* Added UI/Integration tests to `src/ui/dialog.rs` using ratatui's `TestBackend` to verify that the autocomplete popup correctly renders under prompt dialogs at the right coordinate offsets.

### Manual Verification Steps
1. Select a task and press `+` to open the "Add Project" prompt.
2. Begin typing a prefix of an existing project (e.g. `he` if `+health` exists).
3. Verify that the autocomplete popup is rendered below the dialog.
4. Press `Tab` to autocomplete the project name.
5. Press `Enter` to successfully add it to the task.
