### PR TITLE
fix fg color on terminal theme

### DIFF
--- a/src/app/autocomplete.rs
+++ b/src/app/autocomplete.rs
@@ -177,7 +177,8 @@ impl App {
         }
         let idx = self.draft.autocomplete_index().min(matches.len() - 1);
         let chosen = matches[idx].to_string();
-        self.draft.replace_token(target.replace_start, target.replace_end, &chosen);
+        self.draft
+            .replace_token(target.replace_start, target.replace_end, &chosen);
     }
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -172,7 +172,7 @@ pub const TERMINAL: Theme = Theme {
     bg: Color::Reset,
     panel: Color::Reset,
     border: Color::DarkGray,
-    fg: Color::Reset,
+    fg: Color::Rgb(220, 220, 220),
     dim: Color::DarkGray,
     accent: Color::Cyan,
     cursor: Color::DarkGray,
@@ -538,7 +538,7 @@ matched = #b58900
     fn terminal_theme_uses_terminal_palette() {
         assert_eq!(TERMINAL.bg, Color::Reset);
         assert_eq!(TERMINAL.panel, Color::Reset);
-        assert_eq!(TERMINAL.fg, Color::Reset);
+        assert_eq!(TERMINAL.fg, Color::Rgb(220, 220, 220));
         assert_eq!(TERMINAL.pri_a, Color::Red);
         assert!(
             BUILT_IN.iter().any(|t| t.name == TERMINAL.name),


### PR DESCRIPTION
This fixes the cursor fg bug on the terminal theme in issue #17

Used a custom gray color rather than a built in ratatui color to enhance readability. Cargo fmt also made a fix on autocomplete.rs

<img width="818" height="138" alt="Screenshot 2026-06-16 at 10 09 12" src="https://github.com/user-attachments/assets/95caa6dd-f7e6-4182-9659-6466d5bdc6ea" />
