### PR TITLE
tab/enter autocompletes and hides popup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -444,6 +444,7 @@ fn handle_insert(app: &mut App, key: KeyEvent) {
         match key.code {
             KeyCode::Tab | KeyCode::Enter => {
                 app.autocomplete_accept();
+                app.draft.suppress_autocomplete();
                 return;
             }
             _ => {


### PR DESCRIPTION
Resolves issue #60 

Adds suppress auto complete to tab and enter when adding context or project fixing the no action that currently happens on key press