### PR TITLE
Add TokyoNight themes (Moon, Storm, Night, Day)

### DIFF
--- a/docs/themes/tokyonight-day.toml
+++ b/docs/themes/tokyonight-day.toml
@@ -1,0 +1,37 @@
+# TokyoNight Day theme for Tuxedo
+# Original TokyoNight palette: https://github.com/folke/tokyonight.nvim
+# Tuxedo theme adaptation by github.com/ronload
+
+name = TokyoNight Day
+
+bg = #e1e2e7
+panel = #d0d5e3
+border = #a1a6c5
+
+fg = #3760bf
+dim = #848cb5
+accent = #2e7de9
+
+cursor = #c4c8da
+selection = #c4c8da
+selected = #c4c8da
+
+statusbar = #d0d5e3
+status_fg = #6172b0
+mode_fg = #e1e2e7
+mode_bg = #2e7de9
+
+pri_a = #f52a65
+pri_b = #b15c00
+pri_c = #587539
+pri_d = #2e7de9
+pri_other = #9854f1
+
+project = #2e7de9
+context = #118c74
+
+done = #8990b3
+matched = #8c6c3e
+due = #8c6c3e
+overdue = #f52a65
+today = #f52a65

--- a/docs/themes/tokyonight-moon.toml
+++ b/docs/themes/tokyonight-moon.toml
@@ -1,0 +1,37 @@
+# TokyoNight Moon theme for Tuxedo
+# Original TokyoNight palette: https://github.com/folke/tokyonight.nvim
+# Tuxedo theme adaptation by github.com/ronload
+
+name = TokyoNight Moon
+
+bg = #222436
+panel = #1e2030
+border = #444a73
+
+fg = #c8d3f5
+dim = #636da6
+accent = #82aaff
+
+cursor = #2f334d
+selection = #2f334d
+selected = #2f334d
+
+statusbar = #1e2030
+status_fg = #828bb8
+mode_fg = #222436
+mode_bg = #82aaff
+
+pri_a = #ff757f
+pri_b = #ff966c
+pri_c = #c3e88d
+pri_d = #82aaff
+pri_other = #c099ff
+
+project = #82aaff
+context = #4fd6be
+
+done = #545c7e
+matched = #ffc777
+due = #ffc777
+overdue = #ff757f
+today = #ff757f

--- a/docs/themes/tokyonight-night.toml
+++ b/docs/themes/tokyonight-night.toml
@@ -1,0 +1,37 @@
+# TokyoNight Night theme for Tuxedo
+# Original TokyoNight palette: https://github.com/folke/tokyonight.nvim
+# Tuxedo theme adaptation by github.com/ronload
+
+name = TokyoNight Night
+
+bg = #1a1b26
+panel = #16161e
+border = #414868
+
+fg = #c0caf5
+dim = #565f89
+accent = #7aa2f7
+
+cursor = #292e42
+selection = #292e42
+selected = #292e42
+
+statusbar = #16161e
+status_fg = #a9b1d6
+mode_fg = #1a1b26
+mode_bg = #7aa2f7
+
+pri_a = #f7768e
+pri_b = #ff9e64
+pri_c = #9ece6a
+pri_d = #7aa2f7
+pri_other = #bb9af7
+
+project = #7aa2f7
+context = #1abc9c
+
+done = #545c7e
+matched = #e0af68
+due = #e0af68
+overdue = #f7768e
+today = #f7768e

--- a/docs/themes/tokyonight-storm.toml
+++ b/docs/themes/tokyonight-storm.toml
@@ -1,0 +1,37 @@
+# TokyoNight Storm theme for Tuxedo
+# Original TokyoNight palette: https://github.com/folke/tokyonight.nvim
+# Tuxedo theme adaptation by github.com/ronload
+
+name = TokyoNight Storm
+
+bg = #24283b
+panel = #1f2335
+border = #414868
+
+fg = #c0caf5
+dim = #565f89
+accent = #7aa2f7
+
+cursor = #292e42
+selection = #292e42
+selected = #292e42
+
+statusbar = #1f2335
+status_fg = #a9b1d6
+mode_fg = #24283b
+mode_bg = #7aa2f7
+
+pri_a = #f7768e
+pri_b = #ff9e64
+pri_c = #9ece6a
+pri_d = #7aa2f7
+pri_other = #bb9af7
+
+project = #7aa2f7
+context = #1abc9c
+
+done = #545c7e
+matched = #e0af68
+due = #e0af68
+overdue = #f7768e
+today = #f7768e


### PR DESCRIPTION
Adds the four TokyoNight variants as ready-made theme files under `docs/themes/`: Moon, Storm, Night, and Day. Palette sourced from [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim). Token mapping follows the existing Catppuccin themes.

Related to #48 