### PR TITLE
Allow typing date directly into calendar overlay

### DIFF
--- a/src/app/draft_overlay.rs
+++ b/src/app/draft_overlay.rs
@@ -565,10 +565,10 @@ impl App {
                 .unwrap_or("");
             NaiveDate::parse_from_str(value, "%Y-%m-%d").ok()
         };
-        if let Some(date) = parsed_date {
-            if let Some(DraftOverlay::Calendar(s)) = self.draft.overlay_mut() {
-                s.focused = date;
-            }
+        if let Some(date) = parsed_date
+            && let Some(DraftOverlay::Calendar(s)) = self.draft.overlay_mut()
+        {
+            s.focused = date;
         }
     }
 }

--- a/src/app/draft_overlay.rs
+++ b/src/app/draft_overlay.rs
@@ -531,20 +531,65 @@ impl App {
     pub fn calendar_cancel(&mut self) {
         self.draft.set_overlay(None);
     }
+
+    /// Called after each character is typed into the draft while the calendar
+    /// is open in auto-trigger mode. Reads the value typed after `KEY:` at the
+    /// anchor and, if it parses as a complete `YYYY-MM-DD` date, moves the
+    /// calendar's focused cell to that date. Closes the calendar if the user
+    /// has backspaced past the colon (anchor's `KEY:` is no longer in buffer).
+    pub fn calendar_sync_from_draft(&mut self) {
+        let (anchor, target) = {
+            let Some(DraftOverlay::Calendar(s)) = self.draft.overlay() else {
+                return;
+            };
+            let Some(anchor) = s.anchor else {
+                return;
+            };
+            (anchor, s.target)
+        };
+        let key = match target {
+            CalendarTarget::Due => "due",
+            CalendarTarget::Threshold => "t",
+        };
+        let key_with_colon = format!("{key}:");
+        let value_start = anchor + key_with_colon.len();
+        let parsed_date = {
+            let text = self.draft.text();
+            if text.get(anchor..value_start) != Some(key_with_colon.as_str()) {
+                self.draft.set_overlay(None);
+                return;
+            }
+            let value = text[value_start..]
+                .split(|c: char| c.is_ascii_whitespace())
+                .next()
+                .unwrap_or("");
+            NaiveDate::parse_from_str(value, "%Y-%m-%d").ok()
+        };
+        if let Some(date) = parsed_date {
+            if let Some(DraftOverlay::Calendar(s)) = self.draft.overlay_mut() {
+                s.focused = date;
+            }
+        }
+    }
 }
 
-/// Remove the `KEY:` literal at `anchor` and its single leading space, if
-/// any. Used by accept/clear paths when the picker was auto-triggered so the
-/// user's typed prefix doesn't become a duplicate token after we write the
-/// canonical one. No-op if the buffer no longer matches `KEY:` at `anchor`
-/// (e.g. the user edited the line — defensive).
+/// Remove the `KEY:VALUE` token at `anchor` and its single leading space, if
+/// any. Strips the whole token (key, colon, and any typed value) so that
+/// `apply_kv` can write the canonical form without leaving a duplicate or a
+/// bare value fragment in the buffer. No-op if the buffer no longer matches
+/// `KEY:` at `anchor` (e.g. the user edited the line — defensive).
 fn strip_trigger_literal(app: &mut App, key: &str, anchor: usize) {
     let key_with_colon = format!("{key}:");
     let text = app.draft.text();
-    let end = anchor + key_with_colon.len();
-    if text.get(anchor..end) != Some(key_with_colon.as_str()) {
+    let key_colon_end = anchor + key_with_colon.len();
+    if text.get(anchor..key_colon_end) != Some(key_with_colon.as_str()) {
         return;
     }
+    // Extend past any value the user typed (up to next whitespace or EOL).
+    let end = text[key_colon_end..]
+        .find(|c: char| c.is_ascii_whitespace())
+        .map(|i| key_colon_end + i)
+        .unwrap_or(text.len());
     let strip_start = if anchor > 0
         && text
             .as_bytes()
@@ -1481,5 +1526,68 @@ mod tests {
         assert_eq!(task.due.as_deref(), Some("2026-05-07"));
         assert_eq!(task.created_date.as_deref(), Some("2026-05-06"));
         assert!(task.raw.contains("Schedule team offsite"));
+    }
+
+    #[test]
+    fn typing_date_after_trigger_syncs_calendar_focused() {
+        let mut app = build_app("");
+        app.draft_set("Buy milk ".into());
+        for c in "due:".chars() {
+            app.draft_insert_char(c);
+        }
+        app.maybe_open_kv_overlay();
+        // Type a full ISO date into the draft while the calendar is open.
+        for c in "2026-12-25".chars() {
+            app.draft_insert_char(c);
+            app.calendar_sync_from_draft();
+        }
+        let s = app.calendar_state().expect("calendar should still be open");
+        assert_eq!(s.focused, NaiveDate::from_ymd_opt(2026, 12, 25).unwrap());
+    }
+
+    #[test]
+    fn typing_date_after_trigger_accept_writes_single_token() {
+        let mut app = build_app("");
+        app.draft_set("Buy milk ".into());
+        for c in "due:".chars() {
+            app.draft_insert_char(c);
+        }
+        app.maybe_open_kv_overlay();
+        for c in "2026-12-25".chars() {
+            app.draft_insert_char(c);
+            app.calendar_sync_from_draft();
+        }
+        app.calendar_accept();
+        assert_eq!(app.draft.text(), "Buy milk due:2026-12-25");
+        assert_eq!(app.draft.text().matches("due:").count(), 1);
+    }
+
+    #[test]
+    fn backspace_past_colon_closes_calendar() {
+        let mut app = build_app("");
+        for c in "due:".chars() {
+            app.draft_insert_char(c);
+        }
+        app.maybe_open_kv_overlay();
+        // Backspace once removes ':' — anchor's KEY: no longer present.
+        app.draft_backspace();
+        app.calendar_sync_from_draft();
+        assert!(app.draft.overlay().is_none(), "calendar should close");
+    }
+
+    #[test]
+    fn partial_date_does_not_move_focused() {
+        let mut app = build_app("");
+        for c in "due:".chars() {
+            app.draft_insert_char(c);
+        }
+        app.maybe_open_kv_overlay();
+        let initial_focused = app.calendar_state().unwrap().focused;
+        // Type an incomplete date — should not move the focused cell.
+        for c in "2026-12".chars() {
+            app.draft_insert_char(c);
+            app.calendar_sync_from_draft();
+        }
+        assert_eq!(app.calendar_state().unwrap().focused, initial_focused);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,6 +527,17 @@ fn handle_insert_slash_menu(app: &mut App, key: KeyEvent) -> bool {
 }
 
 fn handle_insert_calendar(app: &mut App, key: KeyEvent) {
+    // In auto-trigger mode (anchor set): digit, dash, and backspace are
+    // forwarded to the draft buffer so the user can type the date directly.
+    // The calendar grid tracks the typed date as it becomes valid.
+    if app.calendar_state().is_some_and(|s| s.anchor.is_some()) {
+        let is_date_char = matches!(key.code, KeyCode::Char(c) if c.is_ascii_digit() || c == '-');
+        if is_date_char || matches!(key.code, KeyCode::Backspace) {
+            apply_to_draft(app, key);
+            app.calendar_sync_from_draft();
+            return;
+        }
+    }
     match key.code {
         KeyCode::Char('h') | KeyCode::Left => app.calendar_move(-1, 0),
         KeyCode::Char('l') | KeyCode::Right => app.calendar_move(1, 0),


### PR DESCRIPTION
Closes #28.

When the calendar opens after typing `due:`, all keystrokes were consumed
by the overlay — the only way to pick a date was keyboard navigation or
shortcuts like `t`/`T`. This PR lets you keep typing: digits, dashes, and
backspace pass through to the draft buffer while the calendar is open, and
the grid tracks the typed date live as it becomes valid.

## Changes
- Digit, dash, and backspace keys now pass through to the draft when the
  calendar was auto-triggered (anchor set), so you can type `due:2027-01-01`
  and have the calendar follow along
- Calendar closes cleanly if you backspace past the colon
- Existing shortcuts (t, T, w, m, hjkl) still work alongside typed input
- Updated strip_trigger_literal to handle the typed value that now appears
  in the buffer, so accept produces a single clean token
- Added tests for the new typing flow, backspace-to-close, and the strip fix

**Note**: I left auto-accept out for now, you still press Enter to confirm,
which felt more consistent with the rest of the overlay behavior. Happy to
add it if you'd prefer the calendar close automatically once a valid date
is complete.