### PR TITLE
Added sensible keybindings to `DraftState`

### DIFF
--- a/src/app/draft.rs
+++ b/src/app/draft.rs
@@ -125,6 +125,41 @@ impl DraftState {
         self.reset_autocomplete();
     }
 
+    /// Delete from the previous word boundary to the cursor (`Ctrl-w` / `Ctrl-Backspace`).
+    pub fn delete_word_backward(&mut self) {
+        let pos = self.cursor.byte();
+        if pos == 0 {
+            return;
+        }
+
+        let s = &self.text;
+        let mut start = pos;
+
+        // First eat whitespace before the cursor.
+        while start > 0 {
+            let prev = prev_char_boundary(s, start);
+            if !s.as_bytes()[prev].is_ascii_whitespace() {
+                break;
+            }
+            start = prev;
+        }
+
+        // Then eat the previous word.
+        while start > 0 {
+            let prev = prev_char_boundary(s, start);
+            if s.as_bytes()[prev].is_ascii_whitespace() {
+                break;
+            }
+            start = prev;
+        }
+
+        if start < pos {
+            self.text.drain(start..pos);
+            self.cursor = DraftCursor(start);
+            self.reset_autocomplete();
+        }
+    }
+
     pub fn delete_forward(&mut self) {
         let pos = self.cursor.byte();
         if pos >= self.text.len() {
@@ -291,6 +326,10 @@ impl App {
 
     pub fn draft_backspace(&mut self) {
         self.draft.backspace();
+    }
+
+    pub fn draft_delete_word_backward(&mut self) {
+        self.draft.delete_word_backward();
     }
 
     pub fn draft_delete_forward(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,44 +313,107 @@ enum DraftEffect {
     TextChanged,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DraftAction {
+    Backspace,
+    DeleteForward,
+    MoveLeft,
+    MoveRight,
+    MoveHome,
+    MoveEnd,
+    DeleteWordBackward,
+    InsertChar(char),
+}
+
+fn resolve_draft_shortcut(key: KeyEvent) -> Option<DraftAction> {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+    if ctrl {
+        return match key.code {
+            KeyCode::Char('a') => Some(DraftAction::MoveHome),
+            KeyCode::Char('e') => Some(DraftAction::MoveEnd),
+            KeyCode::Char('w') => Some(DraftAction::DeleteWordBackward),
+            KeyCode::Char('h') => Some(DraftAction::DeleteWordBackward),
+            _ => None,
+        };
+    }
+    None
+}
+
+fn resolve_draft_action(key: KeyEvent) -> Option<DraftAction> {
+    if let Some(action) = resolve_draft_shortcut(key) {
+        return Some(action);
+    }
+
+    match key.code {
+        KeyCode::Backspace => Some(DraftAction::Backspace),
+        KeyCode::Delete => Some(DraftAction::DeleteForward),
+        KeyCode::Left => Some(DraftAction::MoveLeft),
+        KeyCode::Right => Some(DraftAction::MoveRight),
+        KeyCode::Home => Some(DraftAction::MoveHome),
+        KeyCode::End => Some(DraftAction::MoveEnd),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            Some(DraftAction::InsertChar(c))
+        }
+        _ => None,
+    }
+}
+
+fn apply_draft_action(app: &mut App, action: DraftAction) -> DraftEffect {
+    match action {
+        DraftAction::Backspace => {
+            app.draft_backspace();
+            DraftEffect::TextChanged
+        }
+        DraftAction::DeleteForward => {
+            app.draft_delete_forward();
+            DraftEffect::TextChanged
+        }
+        DraftAction::MoveLeft => {
+            app.draft_left();
+            DraftEffect::CursorMoved
+        }
+        DraftAction::MoveRight => {
+            app.draft_right();
+            DraftEffect::CursorMoved
+        }
+        DraftAction::MoveHome => {
+            app.draft_home();
+            DraftEffect::CursorMoved
+        }
+        DraftAction::MoveEnd => {
+            app.draft_end();
+            DraftEffect::CursorMoved
+        }
+        DraftAction::DeleteWordBackward => {
+            app.draft_delete_word_backward();
+            DraftEffect::TextChanged
+        }
+        DraftAction::InsertChar(c) => {
+            app.draft_insert_char(c);
+            DraftEffect::TextChanged
+        }
+    }
+}
+
 /// Apply a standard text-editing key (Backspace/Delete/arrows/Home/End/Char)
 /// to the draft. Centralizes the canonical key list so insert/search/prompt
 /// modes stay in sync as bindings evolve.
 fn apply_to_draft(app: &mut App, key: KeyEvent) -> DraftEffect {
-    match key.code {
-        KeyCode::Backspace => {
-            app.draft_backspace();
-            DraftEffect::TextChanged
-        }
-        KeyCode::Delete => {
-            app.draft_delete_forward();
-            DraftEffect::TextChanged
-        }
-        KeyCode::Char(c) => {
-            app.draft_insert_char(c);
-            DraftEffect::TextChanged
-        }
-        KeyCode::Left => {
-            app.draft_left();
-            DraftEffect::CursorMoved
-        }
-        KeyCode::Right => {
-            app.draft_right();
-            DraftEffect::CursorMoved
-        }
-        KeyCode::Home => {
-            app.draft_home();
-            DraftEffect::CursorMoved
-        }
-        KeyCode::End => {
-            app.draft_end();
-            DraftEffect::CursorMoved
-        }
-        _ => DraftEffect::Unhandled,
-    }
+    resolve_draft_action(key)
+        .map(|action| apply_draft_action(app, action))
+        .unwrap_or(DraftEffect::Unhandled)
 }
 
 fn handle_insert_normal(app: &mut App, key: KeyEvent) {
+    if let Some(action) = resolve_draft_shortcut(key) {
+        apply_draft_action(app, action);
+        return;
+    }
+
     match key.code {
         KeyCode::Enter => {
             let outcome = if app.selection.editing().is_some() {


### PR DESCRIPTION
This adds missing draft shortcuts that are common for text editing.

Added `delete_word_backward` to `DraftState` and introduced `DraftAction` so adding more draft shortcuts is easier and cleaner.

Ctrl-Backspace (passed as Ctrl-h) and Ctrl-w delete the previous word, Ctrl-a moves the cursor to the beginning of the line and
Ctrl-e moves the cursor to the end of the line.

