### PR TITLE
Package project as a nix flake package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .idea/
 target
+# Nix build output
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Fast, keyboard-driven terminal UI for todo.txt";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        {
+          pkgs,
+          ...
+        }:
+        {
+          packages.default = pkgs.callPackage ./package.nix { };
+        };
+      flake = {
+        overlays.default = final: _prev: {
+          tuxedo = self.packages.${final.stdenv.hostPlatform.system}.default;
+        };
+      };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+let
+  cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+  inherit (cargoToml.package) version;
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tuxedo";
+  inherit version;
+  __structuredAttrs = true;
+
+  src = lib.cleanSource ./.;
+
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags = [
+    # Failure
+    "--skip=insert_dialog_after_nl_parse"
+  ];
+
+  meta = {
+    description = "Fast, keyboard-driven terminal UI for todo.txt";
+    homepage = "https://github.com/webstonehq/tuxedo";
+    changelog = "https://github.com/webstonehq/tuxedo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "tuxedo";
+  };
+})


### PR DESCRIPTION
Make project available as a [Nix](https://nixos.org) flake package.
The project is already available in [nixpkgs](https://github.com/nixos/nixpkgs), but the unstable branch lags a bit behind the latest release of this project.

By having the project expose a flake package output directly users who install tuxedo with Nix, can get the latest release as soon as it is make in GitHub.