### PR TITLE
fix: stop continuous config reloads

### DIFF
--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -38,6 +38,7 @@ pub fn spawn(config_path: PathBuf) -> Option<mpsc::Receiver<()>> {
     watcher.watch(&dir, RecursiveMode::NonRecursive).ok()?;
 
     thread::spawn(move || {
+        let _watcher = watcher;
         let mut pending: Option<Instant> = None;
 
         loop {
@@ -54,7 +55,9 @@ pub fn spawn(config_path: PathBuf) -> Option<mpsc::Receiver<()>> {
             if let Some(since) = pending
                 && since.elapsed() >= DEBOUNCE
             {
-                let _ = tx.send(());
+                if tx.send(()).is_err() {
+                    break;
+                }
                 pending = None;
             }
         }
@@ -77,4 +80,27 @@ fn is_relevant(event: &Event, target: &str) -> bool {
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watcher_delivers_changes() {
+        let dir = std::env::temp_dir().join(format!(
+            "tuxedo-config-watcher-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "theme = Muted Slate\n").expect("write config");
+        let rx = spawn(path.clone()).expect("start watcher");
+        std::fs::write(path, "theme = Terminal\n").expect("update config");
+        assert_eq!(rx.recv_timeout(Duration::from_secs(2)), Ok(()));
+        drop(rx);
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,8 +264,8 @@ fn poll_config_reload(app: &mut App, rx: &Option<mpsc::Receiver<()>>) -> bool {
         None => return false,
     };
     match rx.try_recv() {
-        Ok(()) | Err(mpsc::TryRecvError::Disconnected) => {}
-        Err(mpsc::TryRecvError::Empty) => return false,
+        Ok(()) => {}
+        Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => return false,
     }
     let Some(ref path) = app.config_path else {
         return true;
@@ -1420,6 +1420,14 @@ mod tests {
             "2026-05-07".into(),
             Config::default(),
         )
+    }
+
+    #[test]
+    fn disconnected_config_watcher_is_ignored() {
+        let mut app = build_app();
+        let (tx, rx) = mpsc::channel();
+        drop(tx);
+        assert!(!poll_config_reload(&mut app, &Some(rx)));
     }
 
     #[test]


### PR DESCRIPTION
The filesystem watcher was dropped when `spawn()` returned, disconnecting its event channel before any config edits could be observed.

The main loop then treated that disconnection as a change event and reloaded config every poll. This reset transient UI state. For example, theme-picker navigation immediately jumped back, `j`/`k` would not move the cursor, while actual hot reload never worked.

This keeps the watcher alive in its worker thread, treats disconnection as no event, and stops the worker when its receiver closes. Regression tests cover real file changes and disconnected channels.

Tested with full test suite and manually verified that the issue with theme-picker navigation was resolved.