### PR TITLE
Edit tasks with $EDITOR (CLI + TUI)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-external-editor-integration.md
+++ b/docs/superpowers/plans/2026-06-29-external-editor-integration.md
@@ -1,0 +1,678 @@
+# External Editor Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `$EDITOR` launching to tuxedo — a new CLI `edit` command and a TUI `E` keybinding that opens the current task in an external editor, saves the result back through the existing `store.edit_line()` path.
+
+**Architecture:** A new self-contained `editor.rs` module handles editor resolution and temp-file-based editing. The CLI adds an `edit` subcommand that calls it. The TUI adds a `LaunchEditor` action in `apply_action` that suspends the terminal, calls `editor::edit_in_editor()`, restores the terminal, and saves the result.
+
+**Tech Stack:** Rust stdlib (`std::process::Command`, `std::env`, `std::fs`, tempfile via `std::env::temp_dir`), `crossterm` for terminal suspend/restore, `anyhow` for errors.
+
+**Files:**
+- Create: `src/editor.rs`
+- Modify: `src/lib.rs` (register module)
+- Modify: `src/action.rs` (add `LaunchEditor` variant + keybind name)
+- Modify: `src/cmd/mod.rs` (add `edit` subcommand)
+- Modify: `src/main.rs` (add keybinding dispatch + action handler)
+- Modify: `src/app/mod.rs` (add `launch_editor` method on `App`)
+
+---
+
+### Task 1: Add `LaunchEditor` to the `Action` enum
+
+**Files:**
+- Modify: `src/action.rs:1-59`
+
+- [ ] **Step 1: Add the variant**
+
+Add `LaunchEditor` after `OpenThemePicker` (line 58):
+
+```rust
+    /// Edit the current task with $EDITOR (or a fallback editor).
+    LaunchEditor,
+```
+
+- [ ] **Step 2: Add `from_keybind_name` mapping**
+
+Add the mapping inside the match block (after line 108, before `_ => None`):
+
+```rust
+            "launch_editor" => Some(Self::LaunchEditor),
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check 2>&1`
+Expected: compiles cleanly (unused variant warning is OK for now)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/action.rs
+git commit -m "feat(action): add LaunchEditor variant for external editor integration"
+```
+
+---
+
+### Task 2: Create `editor.rs` module
+
+**Files:**
+- Create: `src/editor.rs`
+
+- [ ] **Step 1: Write the module**
+
+```rust
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+struct TempFile {
+    path: PathBuf,
+}
+
+impl TempFile {
+    fn create(content: &str) -> Result<Self> {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "tuxedo-edit-{}-{}.txt",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::write(&path, content)
+            .with_context(|| format!("writing temp file {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    fn read(&self) -> Result<String> {
+        std::fs::read_to_string(&self.path)
+            .with_context(|| format!("reading temp file {}", self.path.display()))
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn resolve_editor() -> Result<String> {
+    if let Ok(editor) = std::env::var("EDITOR") {
+        let editor = editor.trim();
+        if !editor.is_empty() {
+            return Ok(editor.to_string());
+        }
+    }
+    let fallbacks = ["nvim", "vim", "vi", "nano", "emacs", "helix"];
+    for name in fallbacks {
+        if which::which(name).is_ok() {
+            return Ok(name.to_string());
+        }
+    }
+    anyhow::bail!("no editor found (set $EDITOR or install vim/nano)")
+}
+
+fn which(name: &str) -> Result<PathBuf> {
+    if name.contains('/') || name.contains('\\') {
+        let path = PathBuf::from(name);
+        if path.exists() {
+            return Ok(path);
+        }
+        anyhow::bail!("editor '{name}' not found")
+    }
+    #[cfg(unix)]
+    {
+        let path_env = std::env::var_os("PATH").unwrap_or_default();
+        for dir in std::env::split_paths(&path_env) {
+            let candidate = dir.join(name);
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        std::env::var_os("PATH");
+        anyhow::bail!("PATH-based editor lookup not implemented on this platform")
+    }
+    anyhow::bail!("editor '{name}' not found in PATH")
+}
+
+pub fn edit_in_editor(content: &str) -> Result<Option<String>> {
+    let tf = TempFile::create(content)?;
+    let editor = resolve_editor()?;
+    let status = Command::new(&editor)
+        .arg(&tf.path)
+        .status()
+        .with_context(|| format!("spawning editor: {editor}"))?;
+    if !status.success() {
+        anyhow::bail!("editor exited with {}", status);
+    }
+    let new_content = tf.read()?;
+    if new_content.trim() == content.trim() {
+        return Ok(None);
+    }
+    Ok(Some(new_content))
+}
+```
+
+- [ ] **Step 2: Check stdlib-only approach**
+
+The `which` helper above is hand-rolled. Check that `std::env::split_paths` exists in Rust.
+
+Run: `cargo check 2>&1`
+Expected: compiles cleanly
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/editor.rs
+git commit -m "feat(editor): add external editor launching with $EDITOR fallback chain"
+```
+
+---
+
+### Task 3: Register `editor` module in `lib.rs`
+
+**Files:**
+- Modify: `src/lib.rs:1-22`
+
+- [ ] **Step 1: Add the module declaration**
+
+After `pub mod config;` (line 9), add:
+
+```rust
+pub mod editor;
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cargo check 2>&1`
+Expected: compiles cleanly
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(lib): register editor module"
+```
+
+---
+
+### Task 4: Add CLI `edit` subcommand
+
+**Files:**
+- Modify: `src/cmd/mod.rs:42-46` (SUBCOMMANDS table)
+- Modify: `src/cmd/mod.rs:100-119` (command dispatch)
+- Modify: `src/cmd/mod.rs` (add `cmd_edit` function, after `cmd_text_op`)
+
+- [ ] **Step 1: Add `edit` / `e` to SUBCOMMANDS**
+
+Change line 42-46 to include `edit` and `e`:
+
+```rust
+const SUBCOMMANDS: &[&str] = &[
+    "add", "a", "append", "app", "prepend", "prep", "replace", "edit", "e", "pri", "p", "depri",
+    "dp", "done", "do", "complete", "del", "rm", "archive", "list", "ls", "listall", "lsa",
+    "listpri", "lsp", "listproj", "lsprj", "listcon", "lsc",
+];
+```
+
+- [ ] **Step 2: Add dispatch case**
+
+In the `match cmd.as_str()` block (around line 100), add before the `other` arm:
+
+```rust
+        "edit" | "e" => cmd_edit(&mut store, pos, json),
+```
+
+- [ ] **Step 3: Implement `cmd_edit` function**
+
+Add this function after `cmd_text_op` (after line 255):
+
+```rust
+fn cmd_edit(store: &mut Store, pos: &[String], json: bool) -> i32 {
+    if pos.len() < 1 {
+        return usage("edit N");
+    }
+    let len = store.tasks().len();
+    let abs = match parse_index(&pos[0], len) {
+        Ok(i) => i,
+        Err(e) => return err(e),
+    };
+    let old_raw = store.tasks()[abs].raw.clone();
+    match crate::editor::edit_in_editor(&old_raw) {
+        Ok(Some(new_raw)) => {
+            match store.edit_line(abs, &new_raw) {
+                EditOutcome::Saved { abs } => {
+                    let n = abs + 1;
+                    let t = &store.tasks()[abs];
+                    if json {
+                        json_task("edit", n, t);
+                    } else {
+                        println!("{n} {old_raw}");
+                        println!("TODO: Edited task to:");
+                        println!("{n} {}", t.raw);
+                    }
+                    0
+                }
+                EditOutcome::Empty => err("task text cannot be empty"),
+                EditOutcome::OutOfRange => err(format!("no task {}", abs + 1)),
+                EditOutcome::TermNotFound => err("term not found"),
+                EditOutcome::Aborted(_) => err("file changed on disk; nothing changed"),
+                EditOutcome::Error(e) => store_error(json, "edit", e),
+            }
+        }
+        Ok(None) => {
+            // No changes made
+            0
+        }
+        Err(e) => {
+            eprintln!("tuxedo edit: {e}");
+            1
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check 2>&1`
+Expected: compiles cleanly
+
+- [ ] **Step 5: Run existing tests to ensure no regressions**
+
+Run: `cargo test --lib 2>&1`
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cmd/mod.rs
+git commit -m "feat(cmd): add edit subcommand that launches $EDITOR"
+```
+
+---
+
+### Task 5: Add `launch_editor` method to `App`
+
+**Files:**
+- Modify: `src/app/mod.rs` (add method after `save_edit` or near it)
+
+- [ ] **Step 1: Add the method**
+
+Add `launch_editor` to `impl App` in `src/app/mod.rs`. Place it after the `save_edit` method (which reads `selection.editing()`).
+
+First, find `save_edit`:
+
+```bash
+rg "pub fn save_edit" src/app/mutations.rs
+```
+
+It's in `src/app/mutations.rs` at line 103. Add after it (after line 118):
+
+```rust
+    pub fn launch_editor(&mut self) {
+        use std::io::Write as _;
+
+        let idx = match self.selection.editing() {
+            Some(idx) => idx,
+            None => match self.cur_abs() {
+                Some(idx) => idx,
+                None => return,
+            },
+        };
+        let raw = match self.task_raw(idx) {
+            Some(r) => r,
+            None => return,
+        };
+
+        crossterm::terminal::disable_raw_mode().ok();
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen
+        );
+
+        let result = crate::editor::edit_in_editor(&raw);
+
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::EnterAlternateScreen
+        );
+        crossterm::terminal::enable_raw_mode().ok();
+
+        match result {
+            Ok(Some(new_raw)) => {
+                match self.store.edit_line(idx, &new_raw) {
+                    EditOutcome::Saved { abs } => {
+                        self.flash("saved");
+                        self.after_mutation(abs);
+                    }
+                    EditOutcome::Empty => self.flash("task text cannot be empty"),
+                    EditOutcome::OutOfRange | EditOutcome::TermNotFound => {}
+                    EditOutcome::Aborted(r) => self.handle_reconcile_abort(r),
+                    EditOutcome::Error(e) => self.flash(format!("invalid: {e}")),
+                }
+            }
+            Ok(None) => {
+                self.flash("no changes");
+            }
+            Err(e) => {
+                self.flash(format!("editor error: {e}"));
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Add the `use` imports needed in `mutations.rs`**
+
+The file already imports from `crate::core` but needs `crossterm`. Check existing imports at the top of `src/app/mutations.rs`:
+
+```bash
+head -20 src/app/mutations.rs
+```
+
+Add these imports if not already present:
+
+At the top, add:
+
+```rust
+use crossterm::Executor;
+```
+
+Actually, `crossterm::execute!` doesn't need a `use` import (it's a macro). But we need `use std::io::Write` for the macro. The file likely already imports this. Let me check.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check 2>&1`
+Expected: compiles cleanly
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/mutations.rs
+git commit -m "feat(app): add launch_editor method for external editor in TUI"
+```
+
+---
+
+### Task 6: Wire `LaunchEditor` action to the TUI keybinding
+
+**Files:**
+- Modify: `src/main.rs:771-839` (add `E` in `resolve_normal_key`)
+- Modify: `src/main.rs:1082-1093` (add `LaunchEditor` handler in `apply_action`)
+- Modify: `src/main.rs:867-868` (add `LaunchEditor` to archive read-only guard)
+
+- [ ] **Step 1: Add `E` keybinding in `resolve_normal_key`**
+
+After line 783 (`KeyCode::Char('i') => Action::BeginEditInsert,`), add:
+
+```rust
+        KeyCode::Char('E') => Action::LaunchEditor,
+```
+
+- [ ] **Step 2: Add `LaunchEditor` to archive read-only guard**
+
+In `apply_action`, line 867-868, add `LaunchEditor` to the set of disallowed actions in archive view:
+
+```rust
+            | Action::BeginEdit
+            | Action::BeginEditInsert
+            | Action::LaunchEditor
+```
+
+- [ ] **Step 3: Add handler in `apply_action`**
+
+After the `Action::Reschedule` handler (around line 1091, before the closing `}` of the match block), add:
+
+```rust
+        Action::LaunchEditor => {
+            app.launch_editor();
+        }
+```
+
+- [ ] **Step 4: Verify compilation and run tests**
+
+Run: `cargo check 2>&1 && cargo test --lib 2>&1`
+Expected: compiles and all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(tui): wire E keybinding to LaunchEditor action with terminal suspend"
+```
+
+---
+
+### Task 7: Write unit tests
+
+**Files:**
+- Modify: `src/editor.rs` (add `#[cfg(test)]` block)
+- Modify: `src/cmd/mod.rs` (add test for `edit` subcommand)
+- Modify: `src/main.rs` (add test for `E` keybinding resolves to `LaunchEditor`)
+
+- [ ] **Step 1: Add editor resolution test**
+
+At the bottom of `src/editor.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_editor_respects_env() {
+        std::env::set_var("EDITOR", "my-editor");
+        let result = resolve_editor();
+        std::env::remove_var("EDITOR");
+        // Should return the set value, even if my-editor doesn't exist
+        assert_eq!(result.unwrap(), "my-editor");
+    }
+
+    #[test]
+    fn resolve_editor_falls_back_when_unset() {
+        // Save and clear EDITOR
+        let saved = std::env::var("EDITOR").ok();
+        std::env::remove_var("EDITOR");
+        let result = resolve_editor();
+        if let Some(v) = saved {
+            std::env::set_var("EDITOR", v);
+        }
+        // Should find something or return an error; both are fine in test
+        match result {
+            Ok(_) => {} // found an editor in PATH
+            Err(e) => assert!(
+                e.to_string().contains("no editor found"),
+                "unexpected error: {e}"
+            ),
+        }
+    }
+
+    #[test]
+    fn resolve_editor_uses_env_var() {
+        std::env::set_var("EDITOR", "/usr/bin/vim");
+        let result = resolve_editor().unwrap();
+        std::env::remove_var("EDITOR");
+        assert_eq!(result, "/usr/bin/vim");
+    }
+
+    #[test]
+    fn resolve_editor_trims_env_value() {
+        std::env::set_var("EDITOR", "  nano  ");
+        let result = resolve_editor().unwrap();
+        std::env::remove_var("EDITOR");
+        assert_eq!(result, "nano");
+    }
+
+    #[test]
+    fn resolve_editor_finds_system_editor_when_env_unset() {
+        let saved = std::env::var("EDITOR").ok();
+        std::env::remove_var("EDITOR");
+        let result = resolve_editor();
+        if let Some(v) = saved {
+            std::env::set_var("EDITOR", v);
+        }
+        assert!(
+            result.is_ok(),
+            "resolve_editor should find a system editor: {result:?}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Add keybinding resolution test**
+
+In `src/main.rs` tests block (after line 1116), add:
+
+```rust
+    #[test]
+    fn e_resolves_to_launch_editor() {
+        let mut app = mini_app();
+        let action = resolve(&mut app, key('E'));
+        assert_eq!(action, Some(Action::LaunchEditor));
+    }
+```
+
+- [ ] **Step 3: Add CLI `edit` subcommand test**
+
+In `src/cmd/mod.rs` tests block, add a test that verifies `edit` is recognized as a subcommand:
+
+```rust
+    #[test]
+    fn edit_subcommand_recognized() {
+        let args: Vec<String> = ["edit".into(), "1".into()].into();
+        let idx = find_subcommand(&args);
+        assert_eq!(idx, Some(0));
+    }
+
+    #[test]
+    fn e_alias_recognized() {
+        let args: Vec<String> = ["e".into(), "1".into()].into();
+        let idx = find_subcommand(&args);
+        assert_eq!(idx, Some(0));
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib 2>&1`
+Expected: all tests pass (the `edit_in_editor` test may be skipped if no editor; that's OK)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/editor.rs src/main.rs src/cmd/mod.rs
+git commit -m "test: add tests for editor integration"
+```
+
+---
+
+### Task 8: End-to-end verification
+
+- [ ] **Step 1: Test CLI `edit` command with a test file**
+
+```bash
+export TODO_FILE=/tmp/test-todo-edit.txt
+echo "foo +bar @home" > $TODO_FILE
+tuxedo edit 1
+# Should open editor, make changes, save, exit
+# Verify the file was updated
+cat $TODO_FILE
+rm $TODO_FILE
+unset TODO_FILE
+```
+
+- [ ] **Step 2: Test TUI `E` keybinding**
+
+```bash
+export TODO_FILE=/tmp/test-todo-tui.txt
+echo "test task one" > $TODO_FILE
+echo "test task two" >> $TODO_FILE
+tuxedo
+# Press E on first task → editor opens → change text → save/exit
+# Verify TUI shows updated text
+# Press E on second task → change text → save/exit
+cat $TODO_FILE
+rm $TODO_FILE
+unset TODO_FILE
+```
+
+- [ ] **Step 3: Test `$EDITOR` unset fallback**
+
+```bash
+unset EDITOR
+export TODO_FILE=/tmp/test-fallback.txt
+echo "fallback test" > $TODO_FILE
+tuxedo edit 1
+# Should find and open vim/nvim/nano
+rm $TODO_FILE
+unset TODO_FILE
+```
+
+- [ ] **Step 4: Test no-changes flow**
+
+```bash
+export TODO_FILE=/tmp/test-nochange.txt
+export EDITOR=true  # true exits 0 without changing file
+echo "unchanged task" > $TODO_FILE
+tuxedo edit 1
+# Should print nothing or "No changes"
+cat $TODO_FILE  # Should still say "unchanged task"
+rm $TODO_FILE
+unset EDITOR
+unset TODO_FILE
+```
+
+- [ ] **Step 5: Test error when no editor exists**
+
+```bash
+unset EDITOR
+# In an env with no vim/nano (like CI):
+tuxedo edit 1 2>&1
+# Expected: "tuxedo edit: no editor found" on stderr
+```
+
+---
+
+### Task 9: Run full test suite and lint
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+cargo test 2>&1
+```
+Expected: all tests pass (lib, integration, snapshots)
+
+- [ ] **Step 2: Run clippy**
+
+```bash
+cargo clippy -- -D warnings 2>&1
+```
+Expected: no warnings
+
+- [ ] **Step 3: Final commit (if any fixes needed)**
+
+```bash
+git add -A && git diff --cached --stat
+# Commit if there are changes from lints/test fixes
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `cargo build` succeeds
+- [ ] `cargo test` all pass
+- [ ] `cargo clippy` clean
+- [ ] `tuxedo edit 1` opens $EDITOR with task 1's raw text
+- [ ] `tuxedo edit 1` with no changes exits cleanly
+- [ ] `tuxedo edit 1` with empty result shows error
+- [ ] TUI `E` key suspends terminal, launches editor, restores
+- [ ] TUI `e` and `i` inline editing remain unchanged
+- [ ] TUI `E` in archive view flashes "read-only in archive"
+- [ ] `$EDITOR` unset falls back to vim/nvim/nano/emacs/helix
+- [ ] `$EDITOR` set to nonexistent editor shows error

--- a/docs/superpowers/specs/2026-06-29-external-editor-integration-design.md
+++ b/docs/superpowers/specs/2026-06-29-external-editor-integration-design.md
@@ -1,0 +1,159 @@
+# External Editor Integration — Design Spec
+
+**Date**: 2026-06-29
+
+## Summary
+
+Add `$EDITOR` integration to tuxedo so users can edit todo items in a real text editor. Two integration points: a new CLI `edit` command and a TUI keybinding (`E`).
+
+## Architecture
+
+New module: `src/editor.rs` — self-contained, zero dependencies beyond stdlib.
+
+```
+editor.rs
+  └── pub fn edit_in_editor(content: &str) -> anyhow::Result<Option<String>>
+```
+
+The function writes content to a temp file, resolves and spawns the editor, blocks until exit, reads the result, cleans up, and returns the new text (or `None` if unchanged).
+
+Callers:
+- `src/cmd/mod.rs` — for CLI `edit` command
+- `src/main.rs` — for TUI `LaunchEditor` action
+
+Both call the same `edit_in_editor()`, then pass results through the existing `store.edit_line()` path.
+
+## Components
+
+### 1. `editor.rs` module
+
+Public API:
+
+```rust
+pub fn edit_in_editor(content: &str) -> anyhow::Result<Option<String>>
+```
+
+**Temp file**: Created in `std::env::temp_dir()` with prefix `tuxedo-edit-`. File is guaranteed cleaned up on return (both success and error paths) via a `scopeguard`-style drop guard.
+
+**Editor resolution**:
+1. Check `$EDITOR` env var. If set and it's a bare name (no `/` in it), search `$PATH`. If found, use it.
+2. Fall back through a hardcoded search list: `nvim`, `vim`, `vi`, `nano`, `emacs`, `helix`
+3. If nothing found, return `anyhow::Error("no editor found")`
+
+**Process spawning**: `std::process::Command::new(editor).arg(&temp_path).status()`. Blocks. If exit code is non-zero, still returns the file content (user might have opened, made no changes, saved, exited). Only errors on spawn failure.
+
+**Return value**:
+- `Ok(Some(text))` if file content differs from input (whitespace-trimmed comparison)
+- `Ok(None)` if unchanged — caller can skip the store mutation
+- `Err(...)` if editor couldn't launch or temp file couldn't be read
+
+### 2. CLI `edit` command
+
+New entry in `src/cmd/mod.rs` `SUBCOMMANDS`:
+
+```
+"edit" => ["e"]
+```
+
+**Usage**: `tuxedo edit <N>`
+
+**Behavior**:
+1. Parse task number `N` (1-based)
+2. Open `Store`, reconcile against disk (same pattern as `replace`)
+3. Get task `N`'s raw text, pass to `edit_in_editor()`
+4. On `Ok(Some(new_text))`: call `store.edit_line(abs, &new_text)`, print output
+5. On `Ok(None)`: print "No changes." exit 0
+6. On trimmed-empty text: error "task text cannot be empty"
+7. On `Err`: print error to stderr, exit 1
+8. Supports `--json` flag (as other commands do)
+
+No changes to `replace`, `append`, or `prepend`.
+
+### 3. TUI `LaunchEditor` action
+
+**Keybinding**: `E` in Normal mode maps to `Action::LaunchEditor`.
+
+Registered in `src/keybinds.rs` defaults and in `src/main.rs` action dispatch.
+
+**Flow** in `handle_normal()`:
+
+```
+Action::LaunchEditor => {
+    let Some(abs) = app.selection.editing()
+        .or_else(|| app.visibility.cursor_abs()) else { return };
+
+    let raw = app.store.tasks[abs].raw.clone();
+
+    // Suspend terminal
+    crossterm::terminal::disable_raw_mode()?;
+    crossterm::execute!(stdout(), crossterm::terminal::LeaveAlternateScreen)?;
+
+    let result = editor::edit_in_editor(&raw);
+
+    // Restore terminal
+    crossterm::execute!(stdout(), crossterm::terminal::EnterAlternateScreen)?;
+    crossterm::terminal::enable_raw_mode()?;
+
+    // crossterm resize events will be picked up by the
+    // existing event loop on the next iteration
+
+    match result {
+        Ok(Some(new_raw)) => {
+            app.store.edit_line(abs, &new_raw);
+            app.after_mutation(abs);
+            app.flash.show("saved");
+        }
+        Ok(None) => {
+            app.flash.show("no changes");
+        }
+        Err(e) => {
+            app.flash.show(format!("editor error: {e}"));
+        }
+    }
+
+    // Full re-render
+    app.needs_redraw = true;
+}
+```
+
+**Terminal lifecycle**:
+1. Before suspend: `disable_raw_mode()` + `LeaveAlternateScreen` — returns terminal to "normal" state so the editor can use it. The ratatui `Terminal` object stays alive; only the terminal mode changes.
+2. After editor exits: `EnterAlternateScreen` + `enable_raw_mode()` — re-enters TUI mode. A full re-render is forced to repaint the screen.
+3. No additional hook re-initialization needed: the project uses Rust's default panic handler, and crossterm `Resize` events continue to fire through the existing event loop.
+
+**Edge cases**:
+- Pressing `E` with no tasks visible: no-op
+- Pressing `E` in Insert mode / any overlay: ignored (only Normal mode)
+- Visual mode multi-selection: edits the primary selection, same as `e` does
+- Editor crashes (non-zero exit): content still read, user may have saved before crash
+
+## Error Handling
+
+| Scenario | CLI behavior | TUI behavior |
+|----------|-------------|--------------|
+| No editor found | stderr error, exit 1 | flash "no editor found" |
+| Temp file creation failure | stderr error, exit 1 | flash "temp file error" |
+| Editor spawn failure | stderr error, exit 1 | flash "editor error: {msg}" |
+| Task N out of range | stderr "task N not found" | N/A (always on valid task) |
+| External file modified | "aborted: file modified" | Same as existing reconcile path |
+| Editor returns empty text | stderr "task text cannot be empty", exit 1 | flash "cannot be empty", keep old text |
+
+## Testing
+
+- Unit tests in `src/editor.rs`: editor resolution logic (parsable in tests, mock process spawning not required)
+- Unit test: `edit` command arg parsing in `src/cmd/mod.rs`
+- Unit test: `LaunchEditor` action dispatch in `src/main.rs` test block
+
+Manual verification:
+- `tuxedo edit 1` with item 1
+- `TUXEDO_TEST_FILE=/tmp/test-todo.txt tuxedo edit 1` with a test file
+- TUI: open tuxedo, press `E` on a task, edit in vim, verify save
+- TUI: ensure `e`/`i` inline editing still works unchanged
+- TUI: ensure terminal state is clean after editor close (no leftover chars, correct sizing)
+
+## Non-Goals
+
+- Inline $EDITOR within the TUI without suspend (complex, fragile)
+- Multiple-task batch editing in $EDITOR (future possibility, not v1)
+- Editor configuration (syntax highlighting, file type detection for temp files)
+- Windows terminal suspend support (out of scope for initial implementation)

--- a/src/action.rs
+++ b/src/action.rs
@@ -59,6 +59,8 @@ pub enum Action {
     /// Open the theme picker dialog (j/k to preview, Enter to accept).
     OpenThemePicker,
     ChangeWeekStart,
+    /// Edit the current task with $EDITOR (or a fallback editor).
+    LaunchEditor,
 }
 
 impl Action {
@@ -112,6 +114,7 @@ impl Action {
             "open_share" | "share" => Some(Self::OpenShare),
             "open_theme_picker" | "theme_picker" => Some(Self::OpenThemePicker),
             "change_week_start" => Some(Self::ChangeWeekStart),
+            "launch_editor" => Some(Self::LaunchEditor),
             _ => None,
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -113,9 +113,6 @@ pub struct App {
     /// `None` in tests/examples that don't care about the value.
     pub config_path: Option<PathBuf>,
     pub should_quit: bool,
-    /// Set after `launch_editor` restores the terminal so `run()` clears the
-    /// Terminal's back buffer before the next draw — avoids stale diffs.
-    pub needs_clear: bool,
     visible_cache: Vec<usize>,
     /// Parallel to `visible_cache`: `visible_groups[i]` is the group key for
     /// the row at `visible_cache[i]`. `GroupKey::None` for List under
@@ -158,6 +155,9 @@ pub struct App {
     /// Path queued for opening in the user's editor after the TUI temporarily
     /// restores the terminal. Set by OpenNote and drained by the run loop.
     pending_editor_path: Option<PathBuf>,
+    /// Task index and raw text queued for editing in $EDITOR. Set by
+    /// `LaunchEditor` and drained by the run loop after terminal restore.
+    pending_editor_task: Option<(usize, String)>,
     /// Theme index captured when the theme picker opened, so cancel
     /// can restore it.
     theme_pick_orig: usize,
@@ -209,7 +209,6 @@ impl App {
             file_path,
             config_path: None,
             should_quit: false,
-            needs_clear: false,
             visible_cache: Vec::new(),
             visible_groups: Vec::new(),
             latest_version: None,
@@ -222,6 +221,7 @@ impl App {
             share: None,
             notes_dir: note_dir,
             pending_editor_path: None,
+            pending_editor_task: None,
             theme_pick_orig: 0,
             week_start: WeekStart::Sunday,
         };
@@ -452,6 +452,14 @@ impl App {
 
     pub fn take_pending_editor_path(&mut self) -> Option<PathBuf> {
         self.pending_editor_path.take()
+    }
+
+    pub fn start_editor_edit(&mut self, idx: usize, raw: String) {
+        self.pending_editor_task = Some((idx, raw));
+    }
+
+    pub fn take_pending_editor_task(&mut self) -> Option<(usize, String)> {
+        self.pending_editor_task.take()
     }
 
     /// True when at least one task is marked done. Used by the binary to

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -113,6 +113,9 @@ pub struct App {
     /// `None` in tests/examples that don't care about the value.
     pub config_path: Option<PathBuf>,
     pub should_quit: bool,
+    /// Set after `launch_editor` restores the terminal so `run()` clears the
+    /// Terminal's back buffer before the next draw — avoids stale diffs.
+    pub needs_clear: bool,
     visible_cache: Vec<usize>,
     /// Parallel to `visible_cache`: `visible_groups[i]` is the group key for
     /// the row at `visible_cache[i]`. `GroupKey::None` for List under
@@ -206,6 +209,7 @@ impl App {
             file_path,
             config_path: None,
             should_quit: false,
+            needs_clear: false,
             visible_cache: Vec::new(),
             visible_groups: Vec::new(),
             latest_version: None,

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -145,6 +145,7 @@ impl App {
             crossterm::terminal::EnterAlternateScreen
         );
         crossterm::terminal::enable_raw_mode().ok();
+        self.needs_clear = true;
 
         match result {
             Ok(Some(new_raw)) => {

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -119,37 +119,13 @@ impl App {
         }
     }
 
-    pub fn launch_editor(&mut self) {
-        let idx = match self.selection.editing() {
-            Some(idx) => idx,
-            None => match self.cur_abs() {
-                Some(idx) => idx,
-                None => return,
-            },
+    pub fn finish_editor_edit(&mut self, result: &anyhow::Result<Option<String>>) {
+        let Some((idx, _old_raw)) = self.pending_editor_task.take() else {
+            return;
         };
-        let raw = match self.task_raw(idx) {
-            Some(r) => r,
-            None => return,
-        };
-
-        crossterm::terminal::disable_raw_mode().ok();
-        let _ = crossterm::execute!(
-            std::io::stdout(),
-            crossterm::terminal::LeaveAlternateScreen
-        );
-
-        let result = crate::editor::edit_in_editor(&raw);
-
-        let _ = crossterm::execute!(
-            std::io::stdout(),
-            crossterm::terminal::EnterAlternateScreen
-        );
-        crossterm::terminal::enable_raw_mode().ok();
-        self.needs_clear = true;
-
         match result {
             Ok(Some(new_raw)) => {
-                match self.store.edit_line(idx, &new_raw) {
+                match self.store.edit_line(idx, new_raw) {
                     EditOutcome::Saved { abs } => {
                         self.flash("saved");
                         self.after_mutation(abs);

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -120,8 +120,6 @@ impl App {
     }
 
     pub fn launch_editor(&mut self) {
-        use std::io::Write as _;
-
         let idx = match self.selection.editing() {
             Some(idx) => idx,
             None => match self.cur_abs() {

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -119,6 +119,57 @@ impl App {
         }
     }
 
+    pub fn launch_editor(&mut self) {
+        use std::io::Write as _;
+
+        let idx = match self.selection.editing() {
+            Some(idx) => idx,
+            None => match self.cur_abs() {
+                Some(idx) => idx,
+                None => return,
+            },
+        };
+        let raw = match self.task_raw(idx) {
+            Some(r) => r,
+            None => return,
+        };
+
+        crossterm::terminal::disable_raw_mode().ok();
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen
+        );
+
+        let result = crate::editor::edit_in_editor(&raw);
+
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::EnterAlternateScreen
+        );
+        crossterm::terminal::enable_raw_mode().ok();
+
+        match result {
+            Ok(Some(new_raw)) => {
+                match self.store.edit_line(idx, &new_raw) {
+                    EditOutcome::Saved { abs } => {
+                        self.flash("saved");
+                        self.after_mutation(abs);
+                    }
+                    EditOutcome::Empty => self.flash("task text cannot be empty"),
+                    EditOutcome::OutOfRange | EditOutcome::TermNotFound => {}
+                    EditOutcome::Aborted(r) => self.handle_reconcile_abort(r),
+                    EditOutcome::Error(e) => self.flash(format!("invalid: {e}")),
+                }
+            }
+            Ok(None) => {
+                self.flash("no changes");
+            }
+            Err(e) => {
+                self.flash(format!("editor error: {e}"));
+            }
+        }
+    }
+
     pub fn add_project_to_current(&mut self, name: &str) {
         let Some(abs) = self.cur_abs() else {
             return;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -256,7 +256,7 @@ fn cmd_text_op(store: &mut Store, pos: &[String], json: bool, op: TextOp) -> i32
 }
 
 fn cmd_edit(store: &mut Store, pos: &[String], json: bool) -> i32 {
-    if pos.len() < 1 {
+    if pos.is_empty() {
         return usage("edit N");
     }
     let len = store.tasks().len();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -810,4 +810,18 @@ mod tests {
         assert_eq!(f.context.as_deref(), Some("home"));
         assert_eq!(f.search, "pay rent");
     }
+
+    #[test]
+    fn edit_subcommand_recognized() {
+        let args: Vec<String> = ["edit".into(), "1".into()].into();
+        let idx = find_subcommand(&args);
+        assert_eq!(idx, Some(0));
+    }
+
+    #[test]
+    fn e_alias_recognized() {
+        let args: Vec<String> = ["e".into(), "1".into()].into();
+        let idx = find_subcommand(&args);
+        assert_eq!(idx, Some(0));
+    }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -40,9 +40,9 @@ fn parse_args(rest: &[String]) -> Result<Args, String> {
 
 /// Every recognized subcommand and alias.
 const SUBCOMMANDS: &[&str] = &[
-    "add", "a", "append", "app", "prepend", "prep", "replace", "pri", "p", "depri", "dp", "done",
-    "do", "complete", "del", "rm", "archive", "list", "ls", "listall", "lsa", "listpri", "lsp",
-    "listproj", "lsprj", "listcon", "lsc",
+    "add", "a", "append", "app", "prepend", "prep", "replace", "edit", "e", "pri", "p", "depri",
+    "dp", "done", "do", "complete", "del", "rm", "archive", "list", "ls", "listall", "lsa",
+    "listpri", "lsp", "listproj", "lsprj", "listcon", "lsc",
 ];
 
 /// Locate the subcommand: the first non-global token, if it is a known
@@ -112,6 +112,7 @@ pub fn run(argv: &[String]) -> Result<Option<i32>> {
         "listpri" | "lsp" => cmd_listpri(&store, pos, json),
         "listproj" | "lsprj" => cmd_listtags(&store, json, TagKind::Project),
         "listcon" | "lsc" => cmd_listtags(&store, json, TagKind::Context),
+        "edit" | "e" => cmd_edit(&mut store, pos, json),
         other => {
             eprintln!("tuxedo: unknown command: {other}");
             2
@@ -251,6 +252,48 @@ fn cmd_text_op(store: &mut Store, pos: &[String], json: bool, op: TextOp) -> i32
         EditOutcome::TermNotFound => err("term not found"),
         EditOutcome::Aborted(_) => err("file changed on disk; nothing changed"),
         EditOutcome::Error(e) => store_error(json, name, e),
+    }
+}
+
+fn cmd_edit(store: &mut Store, pos: &[String], json: bool) -> i32 {
+    if pos.len() < 1 {
+        return usage("edit N");
+    }
+    let len = store.tasks().len();
+    let abs = match parse_index(&pos[0], len) {
+        Ok(i) => i,
+        Err(e) => return err(e),
+    };
+    let old_raw = store.tasks()[abs].raw.clone();
+    match crate::editor::edit_in_editor(&old_raw) {
+        Ok(Some(new_raw)) => {
+            match store.edit_line(abs, &new_raw) {
+                EditOutcome::Saved { abs } => {
+                    let n = abs + 1;
+                    let t = &store.tasks()[abs];
+                    if json {
+                        json_task("edit", n, t);
+                    } else {
+                        println!("{n} {old_raw}");
+                        println!("TODO: Edited task to:");
+                        println!("{n} {}", t.raw);
+                    }
+                    0
+                }
+                EditOutcome::Empty => err("task text cannot be empty"),
+                EditOutcome::OutOfRange => err(format!("no task {}", abs + 1)),
+                EditOutcome::TermNotFound => err("term not found"),
+                EditOutcome::Aborted(_) => err("file changed on disk; nothing changed"),
+                EditOutcome::Error(e) => store_error(json, "edit", e),
+            }
+        }
+        Ok(None) => {
+            0
+        }
+        Err(e) => {
+            eprintln!("tuxedo edit: {e}");
+            1
+        }
     }
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -91,3 +91,38 @@ pub fn edit_in_editor(content: &str) -> Result<Option<String>> {
     }
     Ok(Some(new_content))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_editor_uses_env_var() {
+        unsafe { std::env::set_var("EDITOR", "/usr/bin/vim"); }
+        let result = resolve_editor().unwrap();
+        unsafe { std::env::remove_var("EDITOR"); }
+        assert_eq!(result, "/usr/bin/vim");
+    }
+
+    #[test]
+    fn resolve_editor_trims_env_value() {
+        unsafe { std::env::set_var("EDITOR", "  nano  "); }
+        let result = resolve_editor().unwrap();
+        unsafe { std::env::remove_var("EDITOR"); }
+        assert_eq!(result, "nano");
+    }
+
+    #[test]
+    fn resolve_editor_finds_system_editor_when_env_unset() {
+        let saved = std::env::var("EDITOR").ok();
+        unsafe { std::env::remove_var("EDITOR"); }
+        let result = resolve_editor();
+        if let Some(v) = saved {
+            unsafe { std::env::set_var("EDITOR", v); }
+        }
+        assert!(
+            result.is_ok(),
+            "resolve_editor should find a system editor: {result:?}"
+        );
+    }
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10,7 +10,7 @@ impl TempFile {
     fn create(content: &str) -> Result<Self> {
         let mut path = std::env::temp_dir();
         path.push(format!(
-            "tuxedo-edit-{}-{}.txt",
+            "tuxedo-edit-{}-{}.todo.txt",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -82,9 +82,7 @@ pub fn edit_in_editor(content: &str) -> Result<Option<String>> {
         .arg(&tf.path)
         .status()
         .with_context(|| format!("spawning editor: {editor}"))?;
-    if !status.success() {
-        anyhow::bail!("editor exited with {}", status);
-    }
+    let _ = status; // ignore exit code — user may have saved successfully
     let new_content = tf.read()?;
     if new_content.trim() == content.trim() {
         return Ok(None);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,93 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+struct TempFile {
+    path: PathBuf,
+}
+
+impl TempFile {
+    fn create(content: &str) -> Result<Self> {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "tuxedo-edit-{}-{}.txt",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::write(&path, content)
+            .with_context(|| format!("writing temp file {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    fn read(&self) -> Result<String> {
+        std::fs::read_to_string(&self.path)
+            .with_context(|| format!("reading temp file {}", self.path.display()))
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn which(name: &str) -> Result<PathBuf> {
+    if name.contains('/') || name.contains('\\') {
+        let path = PathBuf::from(name);
+        if path.exists() {
+            return Ok(path);
+        }
+        anyhow::bail!("editor '{name}' not found")
+    }
+    #[cfg(unix)]
+    {
+        let path_env = std::env::var_os("PATH").unwrap_or_default();
+        for dir in std::env::split_paths(&path_env) {
+            let candidate = dir.join(name);
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // PATH-based lookup not implemented for this platform
+    }
+    anyhow::bail!("editor '{name}' not found in PATH")
+}
+
+fn resolve_editor() -> Result<String> {
+    if let Ok(editor) = std::env::var("EDITOR") {
+        let editor = editor.trim();
+        if !editor.is_empty() {
+            return Ok(editor.to_string());
+        }
+    }
+    let fallbacks = ["nvim", "vim", "vi", "nano", "emacs", "helix"];
+    for name in fallbacks {
+        if which(name).is_ok() {
+            return Ok(name.to_string());
+        }
+    }
+    anyhow::bail!("no editor found (set $EDITOR or install vim/nano)")
+}
+
+pub fn edit_in_editor(content: &str) -> Result<Option<String>> {
+    let tf = TempFile::create(content)?;
+    let editor = resolve_editor()?;
+    let status = Command::new(&editor)
+        .arg(&tf.path)
+        .status()
+        .with_context(|| format!("spawning editor: {editor}"))?;
+    if !status.success() {
+        anyhow::bail!("editor exited with {}", status);
+    }
+    let new_content = tf.read()?;
+    if new_content.trim() == content.trim() {
+        return Ok(None);
+    }
+    Ok(Some(new_content))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod app;
 pub mod cli;
 pub mod clipboard;
 pub mod cmd;
+pub mod editor;
 pub mod config;
 pub mod config_watcher;
 pub mod core;

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,10 +206,6 @@ fn run(
             dirty = true;
         }
         if dirty {
-            if app.needs_clear {
-                terminal.clear()?;
-                app.needs_clear = false;
-            }
             // Extract URL runs from the completed frame before the borrow on
             // terminal ends, then write the OSC 8 overlay directly to the
             // backend writer. Doing this here (rather than inside `ui::draw`)
@@ -233,7 +229,13 @@ fn run(
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     handle_key(app, key, keybinds);
                     if let Some(path) = app.take_pending_editor_path() {
-                        open_path_in_editor(&path)?;
+                        terminal = open_path_in_editor(&path)?;
+                    }
+                    if let Some((_idx, raw)) = app.take_pending_editor_task() {
+                        ratatui::restore();
+                        let result = tuxedo::editor::edit_in_editor(&raw);
+                        terminal = ratatui::try_init()?;
+                        app.finish_editor_edit(&result);
                     }
                     dirty = true;
                 }
@@ -288,24 +290,18 @@ fn poll_config_reload(app: &mut App, rx: &Option<mpsc::Receiver<()>>) -> bool {
     }
 }
 
-fn open_path_in_editor(path: &std::path::Path) -> Result<()> {
+fn open_path_in_editor(path: &std::path::Path) -> Result<DefaultTerminal> {
     let editor = std::env::var("VISUAL")
         .or_else(|_| std::env::var("EDITOR"))
         .unwrap_or_else(|_| "nvim".to_string());
     ratatui::restore();
-    let status = std::process::Command::new(&editor)
+    let result = std::process::Command::new(&editor)
         .arg(path)
         .status()
         .with_context(|| format!("failed to launch editor `{editor}`"));
-    ratatui::crossterm::terminal::enable_raw_mode()?;
-    ratatui::crossterm::execute!(
-        io::stdout(),
-        ratatui::crossterm::terminal::EnterAlternateScreen
-    )?;
-    match status {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+    let terminal = ratatui::try_init()?;
+    result?;
+    Ok(terminal)
 }
 
 fn next_timeout(app: &App) -> Duration {
@@ -1295,7 +1291,11 @@ fn apply_action(app: &mut App, action: Action) {
             app.recompute_visible();
         }
         Action::LaunchEditor => {
-            app.launch_editor();
+            if let Some(idx) = app.cur_abs()
+                && let Some(raw) = app.task_raw(idx)
+            {
+                app.start_editor_edit(idx, raw);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -972,6 +972,7 @@ fn resolve_normal_key(app: &mut App, key: KeyEvent, keybinds: &KeyBindings) -> O
         KeyCode::Char('i') => Action::BeginEditInsert,
         KeyCode::Char('o') => Action::OpenNote,
         KeyCode::Char('O') => Action::CreateOrOpenNote,
+        KeyCode::Char('E') => Action::LaunchEditor,
         KeyCode::Char('x') => Action::ToggleComplete,
         // 'dd' chord. First press arms; second fires.
         KeyCode::Char('d') if app.chord.toggle('d') => Action::Delete,
@@ -1058,6 +1059,7 @@ fn apply_action(app: &mut App, action: Action) {
             Action::BeginAdd
             | Action::BeginEdit
             | Action::BeginEditInsert
+            | Action::LaunchEditor
             | Action::CyclePriority
             | Action::ToggleVisual
             | Action::ToggleSelected
@@ -1286,6 +1288,10 @@ fn apply_action(app: &mut App, action: Action) {
         Action::ChangeWeekStart => {
             app.toggle_week_start_date();
             app.recompute_visible();
+        }
+        Action::LaunchEditor => {
+            app.launch_editor();
+        }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,10 @@ fn run(
             dirty = true;
         }
         if dirty {
+            if app.needs_clear {
+                terminal.clear()?;
+                app.needs_clear = false;
+            }
             // Extract URL runs from the completed frame before the borrow on
             // terminal ends, then write the OSC 8 overlay directly to the
             // backend writer. Doing this here (rather than inside `ui::draw`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1713,6 +1713,7 @@ mod tests {
     }
 
     #[test]
+    #[test]
     fn capital_w_toggles_week_start() {
         let mut app = build_app();
         assert_eq!(resolve(&mut app, key('W')), Some(Action::ChangeWeekStart));
@@ -1805,5 +1806,12 @@ mod tests {
         app.set_search("abc".into());
         handle_search(&mut app, ctrl('u'));
         assert_eq!(app.draft.text(), "");
+    }
+
+    #[test]
+    fn e_resolves_to_launch_editor() {
+        let mut app = build_app();
+        let action = resolve(&mut app, key('E'));
+        assert_eq!(action, Some(Action::LaunchEditor));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1297,7 +1297,6 @@ fn apply_action(app: &mut App, action: Action) {
         Action::LaunchEditor => {
             app.launch_editor();
         }
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,7 @@ fn print_usage() {
     println!("  append, app N TEXT...     append text to task N");
     println!("  prepend, prep N TEXT...   prepend text to task N");
     println!("  replace N TEXT...         replace task N");
+    println!("  edit, e N                 edit task N with $EDITOR (vim, nano, ...)");
     println!("  pri, p N PRIORITY         set priority A-Z on task N");
     println!("  depri, dp N...            remove priority from task N");
     println!("  done, do N...             mark task N complete");


### PR DESCRIPTION
Closes #106

Adds `tuxedo edit N` CLI command and `E` TUI keybinding that open a task's raw text in $EDITOR for full editing. Terminal suspend/restore uses ratatui::restore() + ratatui::try_init(). Temp files named `*.todo.txt` for syntax highlighting plugins. Existing inline editing (`e`/`i`) is untouched.