### PR TITLE
Fix constant config reloaded flashes breaking theme picker

### DIFF
--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -75,6 +75,6 @@ fn is_relevant(event: &Event, target: &str) -> bool {
 
     matches!(
         event.kind,
-        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        EventKind::Create(_) | EventKind::Modify(_)
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,8 @@ fn poll_config_reload(app: &mut App, rx: &Option<mpsc::Receiver<()>>) -> bool {
         None => return false,
     };
     match rx.try_recv() {
-        Ok(()) | Err(mpsc::TryRecvError::Disconnected) => {}
+        Ok(()) => {}
+        Err(mpsc::TryRecvError::Disconnected) => return true,
         Err(mpsc::TryRecvError::Empty) => return false,
     }
     let Some(ref path) = app.config_path else {


### PR DESCRIPTION
Closes #108

On macOS, the config hot-reload watcher fires spurious events causing `config.toml` reloads on every frame, breaking theme picker j/k navigation.

Two fixes:
- Only watch `Create`/`Modify` events (not `Remove`) to avoid tmp-file rename artifacts
- Return early on `TryRecvError::Disconnected` instead of reloading on every frame