### PR TITLE
feature: add subtask with uuid and part of key value pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "qrcode",
  "ratatui",
  "tiny_http",
+ "uuid",
 ]
 
 [[package]]
@@ -1708,9 +1709,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ notify = "8"
 qrcode = { version = "0.14", default-features = false }
 ratatui = "0.30.0"
 tiny_http = "0.12"
+uuid = { version = "1.24.0", features = ["v4"] }
 
 [dev-dependencies]
 insta = "1.47"

--- a/src/action.rs
+++ b/src/action.rs
@@ -12,6 +12,7 @@ pub enum Action {
     HalfPageDown,
     HalfPageUp,
     BeginAdd,
+    BeginAddSubtask,
     /// Edit the current task starting in Normal (vim) mode (`e`).
     BeginEdit,
     /// Edit the current task starting in Insert mode (`i`).
@@ -73,6 +74,7 @@ impl Action {
             "half_page_down" => Some(Self::HalfPageDown),
             "half_page_up" => Some(Self::HalfPageUp),
             "begin_add" | "add" => Some(Self::BeginAdd),
+            "begin_add_subtask" | "add_subtask" => Some(Self::BeginAddSubtask),
             "begin_edit" | "edit" => Some(Self::BeginEdit),
             "begin_edit_insert" | "edit_insert" => Some(Self::BeginEditInsert),
             "toggle_complete" => Some(Self::ToggleComplete),

--- a/src/app/draft.rs
+++ b/src/app/draft.rs
@@ -317,6 +317,11 @@ impl App {
         self.draft.clear();
     }
 
+    pub fn draft_sub(&mut self, uuid: String) {
+        self.draft.clear();
+        self.draft.text = format!("partof:{uuid}")
+    }
+
     /// Seed the edit dialog and open it in Normal mode (`e`), so vim users can
     /// navigate before changing anything.
     pub fn draft_set(&mut self, s: String) {

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -7,6 +7,7 @@ use super::App;
 use super::types::{AddOutcome, View};
 use crate::app::WeekStart;
 use crate::core::AddOutcome as CoreAdd;
+use crate::core::outcome::UUIDOutcome;
 use crate::core::{
     ArchiveDeleteOutcome, ArchiveOutcome, CompleteOutcome, DeleteOutcome, EditOutcome,
     PriorityOutcome, TagOutcome, UnarchiveOutcome, UndoOutcome,
@@ -33,6 +34,10 @@ impl App {
             CompleteOutcome::OutOfRange => {}
             CompleteOutcome::Error(e) => self.flash(format!("complete failed: {e}")),
         }
+    }
+
+    pub fn gen_uuid(&mut self, abs: usize) -> UUIDOutcome {
+        self.store.gen_uuid(abs)
     }
 
     pub fn cycle_priority(&mut self, abs: usize) {

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -78,6 +78,11 @@ pub const ENTRIES: &[PaletteEntry] = &[
         action: Action::CreateOrOpenNote,
     },
     PaletteEntry {
+        label: "add new subtask",
+        keys: "b",
+        action: Action::BeginAddSubtask,
+    },
+    PaletteEntry {
         label: "undo",
         keys: "u",
         action: Action::Undo,

--- a/src/core/mutations.rs
+++ b/src/core/mutations.rs
@@ -3,6 +3,7 @@ use super::outcome::{
     AddOutcome, BulkCompleteOutcome, BulkDeleteOutcome, CompleteOutcome, DeleteOutcome,
     EditOutcome, PriorityOutcome, Reconcile, StoreError, TagOutcome,
 };
+use crate::core::outcome::UUIDOutcome;
 use crate::recurrence::{self, RecSpec};
 use crate::todo::{self, TagError};
 
@@ -64,6 +65,22 @@ impl Store {
                 }
             }
             Err(e) => CompleteOutcome::Error(StoreError::Parse(e)),
+        }
+    }
+
+    pub fn gen_uuid(&mut self, abs: usize) -> UUIDOutcome {
+        match self.reconcile() {
+            Reconcile::Unchanged => {}
+            other => return UUIDOutcome::Aborted(other),
+        }
+        if abs >= self.tasks.len() {
+            return UUIDOutcome::OutOfRange;
+        }
+        self.push_history();
+
+        match self.tasks[abs].gen_uuid() {
+            Ok(uuid) => UUIDOutcome::Added { abs, uuid: uuid },
+            Err(_) => todo!(),
         }
     }
 

--- a/src/core/outcome.rs
+++ b/src/core/outcome.rs
@@ -106,6 +106,16 @@ pub enum EditOutcome {
 }
 
 #[derive(Debug)]
+pub enum UUIDOutcome {
+    Added { abs: usize, uuid: String },
+    Removed { abs: usize, uuid: String },
+    Unchanged { abs: usize, uuid: String },
+    OutOfRange,
+    Aborted(Reconcile),
+    Error(StoreError),
+}
+
+#[derive(Debug)]
 pub enum TagOutcome {
     Added {
         abs: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -972,6 +972,7 @@ fn resolve_normal_key(app: &mut App, key: KeyEvent, keybinds: &KeyBindings) -> O
         KeyCode::Char('i') => Action::BeginEditInsert,
         KeyCode::Char('o') => Action::OpenNote,
         KeyCode::Char('O') => Action::CreateOrOpenNote,
+        KeyCode::Char('b') => Action::BeginAddSubtask,
         KeyCode::Char('x') => Action::ToggleComplete,
         // 'dd' chord. First press arms; second fires.
         KeyCode::Char('d') if app.chord.toggle('d') => Action::Delete,
@@ -1056,6 +1057,7 @@ fn apply_action(app: &mut App, action: Action) {
                 return;
             }
             Action::BeginAdd
+            | Action::BeginAddSubtask
             | Action::BeginEdit
             | Action::BeginEditInsert
             | Action::CyclePriority
@@ -1101,6 +1103,26 @@ fn apply_action(app: &mut App, action: Action) {
             app.mode = Mode::Insert;
             app.draft_clear();
             app.selection.exit_edit();
+        }
+        // TODO: implement adding a new subtask. Test if the task under the cursor already has a
+        // uuid and if not generate one. Add the partof:<parent-uuid> to the subtask
+        Action::BeginAddSubtask => {
+            app.mode = Mode::Insert;
+            if let Some(abs) = app.cur_abs() {
+                let part_of_uuid = app.gen_uuid(abs);
+                match part_of_uuid {
+                    tuxedo::core::outcome::UUIDOutcome::Added { abs, uuid }
+                    | tuxedo::core::outcome::UUIDOutcome::Removed { abs, uuid }
+                    | tuxedo::core::outcome::UUIDOutcome::Unchanged { abs, uuid } => {
+                        app.draft_sub(uuid)
+                    }
+                    tuxedo::core::outcome::UUIDOutcome::OutOfRange => todo!(),
+                    tuxedo::core::outcome::UUIDOutcome::Aborted(reconcile) => todo!(),
+                    tuxedo::core::outcome::UUIDOutcome::Error(store_error) => todo!(),
+                }
+
+                app.selection.exit_edit();
+            }
         }
         Action::BeginEdit => {
             if let Some(abs) = app.cur_abs()

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -56,6 +56,7 @@ pub struct Task {
     /// filter parses it on demand via `crate::threshold`.
     pub threshold: Option<String>,
     pub notes: Vec<String>,
+    pub uuid: Option<String>,
 }
 
 pub fn parse_line(raw: &str) -> Result<Task, ParseError> {
@@ -91,6 +92,7 @@ pub fn parse_line(raw: &str) -> Result<Task, ParseError> {
     let projects = collect_tokens(rest, '+');
     let contexts = collect_tokens(rest, '@');
     let due = find_kv(rest, "due");
+    let uuid = find_kv(rest, "uuid");
     let rec = find_kv(rest, "rec");
     let threshold = find_kv(rest, "t");
     let notes = find_quoted_kv(rest, "note");
@@ -109,6 +111,7 @@ pub fn parse_line(raw: &str) -> Result<Task, ParseError> {
         rec,
         threshold,
         notes,
+        uuid,
     })
 }
 
@@ -279,6 +282,40 @@ impl Task {
             after_x.to_string()
         };
         self.replace_from_raw(&body)
+    }
+
+    // Set or replace this tasks uuid
+    pub fn set_uuid(&mut self, uuid: &str) -> Result<(), ParseError> {
+        let mut found = false;
+        let mut tokens: Vec<String> = self
+            .raw
+            .split(' ')
+            .map(|tok| {
+                if tok.starts_with("uuid:") && !found {
+                    found = true;
+                    format!("uuid:{}", uuid)
+                } else {
+                    tok.to_string()
+                }
+            })
+            .collect();
+        if !found {
+            tokens.push(format!("uuid:{}", uuid));
+        }
+        let new_raw = tokens.join(" ");
+        self.replace_from_raw(&new_raw)
+    }
+
+    /// Generate a uuid for the task if it has none
+    pub fn gen_uuid(&mut self) -> Result<String, ParseError> {
+        match &self.uuid {
+            Some(uuid) => Ok(uuid.clone()),
+            None => {
+                let uuid = uuid::Uuid::new_v4().to_string();
+                self.set_uuid(&uuid)?;
+                Ok(uuid)
+            }
+        }
     }
 
     /// Set or clear this task's priority. The priority byte is replaced in


### PR DESCRIPTION
I started adding subtasks by adding an optional uuid to tasks and referencing it by the tasks that should be a part of that task. This is related to Issue #37 
If this approach is good I can continue the implementation and change the appearence of subtasks so that they are shown bleow their parent task and probably hide the uuid and partof key value pairs.