### PR TITLE
Fix: config hot-reload watcher dropped immediately after spawn()

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -383,7 +383,7 @@ impl App {
     pub fn pick_theme_step(&mut self, forward: bool) {
         let all = theme::all();
         let len = all.len();
-        if len <= 1 {
+        if len <= 1{ 
             return;
         }
         let cur = self.prefs.theme_idx();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -383,7 +383,7 @@ impl App {
     pub fn pick_theme_step(&mut self, forward: bool) {
         let all = theme::all();
         let len = all.len();
-        if len <= 1{ 
+        if len <= 1 { 
             return;
         }
         let cur = self.prefs.theme_idx();

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -38,6 +38,10 @@ pub fn spawn(config_path: PathBuf) -> Option<mpsc::Receiver<()>> {
     watcher.watch(&dir, RecursiveMode::NonRecursive).ok()?;
 
     thread::spawn(move || {
+        // Keep the watcher alive for the life of this thread — dropping it
+        // tears down the OS-level watch (and on macOS/FSEvents, can flush a
+        // burst of stale replayed events right as it's invalidated).
+        let _watcher = watcher;
         let mut pending: Option<Instant> = None;
 
         loop {


### PR DESCRIPTION
**Closes** #113
 
**Fix:** move `watcher` into the background thread (`let _watcher = watcher;`)
so its lifetime matches the thread's, instead of ending the moment `spawn()`
returns.

**Testing:** confirmed via `eprintln!` instrumentation in `reload_config` and
`pick_theme_step` that `reload_config` was firing continuously at startup
with no user interaction, and that `pick_theme_step`'s `cur` index was
always reading back `0`. After the fix, `reload_config` only fires on an
actual edit to `config.toml`, and the theme picker preview steps correctly
through `j`/`k`.

@mikenikles 