### PR TITLE
feature: adding due date range parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The modal keys below apply in Normal mode:
 
 | Key | Action |
 | --- | --- |
-| `/` | search |
+| `/` | search (a `due:` term filters by date range; see [todo.txt format](#todotxt-format)) |
 | `fp` | filter by project (`j` / `k` cycles, `Esc` clears) |
 | `fc` | filter by context (`j` / `k` cycles, `Esc` clears) |
 | `ff` | pick a saved search (`j` / `k` cycles, `Enter` keeps, `Esc` reverts) |
@@ -455,6 +455,14 @@ Standard [todo.txt](https://github.com/todotxt/todo.txt) lines:
   note actions (`o` / `O`): relative paths resolve under `notes_dir`, then
   `$NOTES_DIR`, then `~/notes`. Keys you'd rather not see can be hidden from
   the rows via [`hide_keys`](#hiding-keyvalue-tags)
+- `due:` in the `/`-search box also accepts a range, using the same offset
+  grammar as `rec:` and `t:`: `due:+1w` matches anything due between today
+  and 7 days from now, `due:-3d` matches anything due between 3 days ago and
+  today (both bounds inclusive). The sign defaults to `+` when omitted, so
+  `due:1w` and `due:+1w` mean the same thing. Units are `d` (days), `b`
+  (business days), `w` (weeks), and `m` (months). Only the first `due:` term
+  in a search is used this way; the rest of the query is matched as free text
+  against the task body, same as before
 - `rec:[+]N{d,b,w,m,y}` — recurrence; on completion (`x`), tuxedo inserts
   a fresh copy of the task with `due:` advanced by `N` days, business
   days (Mon–Fri), weeks, months, or years. The `+` prefix means

--- a/src/app/visibility.rs
+++ b/src/app/visibility.rs
@@ -37,9 +37,12 @@ impl App {
     }
 
     fn rebuild_list_cache(&mut self) {
-        let needle = (!self.filter.search.is_empty()).then_some(self.filter.search.as_str());
         let tasks = self.store.tasks();
         let today = self.store.today();
+        // Resolved once, not per task — a `due:` term can drive a
+        // business-day walk in `threshold::shift`.
+        let needle = (!self.filter.search.is_empty())
+            .then(|| filter::resolve_needle(&self.filter.search, today));
 
         let mut idxs: Vec<usize> = (0..tasks.len())
             .filter(|&i| {
@@ -49,7 +52,7 @@ impl App {
                     self.prefs.show_future,
                     today,
                     &self.filter,
-                    needle,
+                    needle.as_ref(),
                 )
             })
             .collect();
@@ -141,6 +144,15 @@ mod tests {
         app.filter.search = "2026".into();
         app.recompute_visible();
         assert_eq!(app.visible_indices().len(), 0);
+    }
+
+    #[test]
+    fn search_due_range_matches_by_due_field_not_literal_text() {
+        let mut app =
+            build_app("in range due:2026-05-10\nout of range due:2026-05-20\nno due date here\n");
+        app.filter.search = "due:+1w".into();
+        app.recompute_visible();
+        assert_eq!(app.visible_indices().len(), 1);
     }
 
     #[test]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -556,10 +556,20 @@ fn filter_from_terms(terms: &[String]) -> Filter {
 /// Indices into `tasks` matching `filter` (with an optional extra predicate),
 /// ordered like todo.sh's default: a case-insensitive sort of the full task
 /// line (`sort -f -k2 -b`), ties broken by file position.
-fn matching_indices(tasks: &[Task], filter: &Filter, extra: impl Fn(&Task) -> bool) -> Vec<usize> {
-    let needle = (!filter.search.is_empty()).then_some(filter.search.as_str());
+fn matching_indices(
+    tasks: &[Task],
+    filter: &Filter,
+    today: &str,
+    extra: impl Fn(&Task) -> bool,
+) -> Vec<usize> {
+    // Resolved once for the whole list rather than per task; see the same
+    // hoist in `app::visibility::rebuild_list_cache`.
+    let needle =
+        (!filter.search.is_empty()).then(|| corefilter::resolve_needle(&filter.search, today));
     let mut idxs: Vec<usize> = (0..tasks.len())
-        .filter(|&i| corefilter::passes_user_filter(&tasks[i], filter, needle) && extra(&tasks[i]))
+        .filter(|&i| {
+            corefilter::passes_user_filter(&tasks[i], filter, needle.as_ref()) && extra(&tasks[i])
+        })
         .collect();
     idxs.sort_by(|&a, &b| {
         tasks[a]
@@ -588,7 +598,7 @@ fn print_rows(tasks: &[Task], idxs: &[usize], width: usize) {
 fn cmd_list(store: &Store, pos: &[String], json: bool) -> i32 {
     let filter = filter_from_terms(pos);
     let tasks = store.tasks();
-    let idxs = matching_indices(tasks, &filter, |_| true);
+    let idxs = matching_indices(tasks, &filter, store.today(), |_| true);
     if json {
         let refs: Vec<(usize, &Task)> = idxs.iter().map(|&i| (i + 1, &tasks[i])).collect();
         println!("{}", json::task_array(&refs));
@@ -608,9 +618,9 @@ fn cmd_list(store: &Store, pos: &[String], json: bool) -> i32 {
 fn cmd_listall(store: &Store, pos: &[String], json: bool) -> i32 {
     let filter = filter_from_terms(pos);
     let tasks = store.tasks();
-    let live = matching_indices(tasks, &filter, |_| true);
+    let live = matching_indices(tasks, &filter, store.today(), |_| true);
     let archived_tasks = store.archive().tasks();
-    let done = matching_indices(archived_tasks, &filter, |_| true);
+    let done = matching_indices(archived_tasks, &filter, store.today(), |_| true);
     if json {
         let live_refs: Vec<(usize, &Task)> = live.iter().map(|&i| (i + 1, &tasks[i])).collect();
         let done_refs: Vec<(usize, &Task)> =
@@ -659,7 +669,7 @@ fn cmd_listpri(store: &Store, pos: &[String], json: bool) -> i32 {
         }
     };
     let tasks = store.tasks();
-    let idxs = matching_indices(tasks, &Filter::default(), |t| match only {
+    let idxs = matching_indices(tasks, &Filter::default(), store.today(), |t| match only {
         Some(c) => t.priority == Some(c),
         None => t.priority.is_some(),
     });

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -10,6 +10,7 @@ use std::cmp::Ordering;
 use chrono::{Datelike, Days, NaiveDate};
 
 use crate::app::{Filter, Sort, WeekStart};
+use crate::due_filter;
 use crate::search::subseq_match_ci;
 use crate::threshold;
 use crate::todo::{self, Task};
@@ -84,10 +85,43 @@ pub fn sort_by_prefs(idxs: &mut [usize], tasks: &[Task], sort: Sort) {
     }
 }
 
+/// A search string resolved once per query: the literal text to
+/// subsequence-match, plus an inclusive `due:` range if the query had a
+/// parseable `due:` term. Building this is not free — a `due:` value can
+/// drive a business-day walk in [`crate::threshold`] — so callers resolve it
+/// once per search change via [`resolve_needle`] and reuse it across every
+/// task, rather than re-parsing per task inside [`passes_user_filter`].
+pub struct ResolvedNeedle {
+    /// Remaining free text to subsequence-match against the task body — the
+    /// original search with any parsed `due:` term removed. Equal to the
+    /// original search string when no `due:` term parsed.
+    pub text: String,
+    due_range: Option<(String, String)>,
+}
+
+/// Resolve `needle` against `today`: pull the first parseable `due:` term out
+/// (if any) and compute its inclusive range, leaving the rest as literal
+/// search text. An unparseable `due:` term, or a second `due:` term, is left
+/// in place as literal text — only the first parseable one is honored.
+pub fn resolve_needle(needle: &str, today: &str) -> ResolvedNeedle {
+    match extract_due_range(needle, today) {
+        Some((rest, range)) => ResolvedNeedle {
+            text: rest,
+            due_range: Some(range),
+        },
+        None => ResolvedNeedle {
+            text: needle.to_string(),
+            due_range: None,
+        },
+    }
+}
+
 /// Project / context / search predicate, shared by every view that honors
 /// user filters. `needle` matches as a case-insensitive subsequence of the
-/// task body — chars must appear in order, gaps allowed.
-pub fn passes_user_filter(t: &Task, filter: &Filter, needle: Option<&str>) -> bool {
+/// task body — chars must appear in order, gaps allowed. When it carries a
+/// resolved `due:` range, that's matched against `t.due` instead; see
+/// [`resolve_needle`].
+pub fn passes_user_filter(t: &Task, filter: &Filter, needle: Option<&ResolvedNeedle>) -> bool {
     if let Some(p) = &filter.project
         && !t.projects.iter().any(|x| x == p)
     {
@@ -99,12 +133,41 @@ pub fn passes_user_filter(t: &Task, filter: &Filter, needle: Option<&str>) -> bo
         return false;
     }
     if let Some(needle) = needle {
-        let body = todo::body_after_priority(&t.raw);
-        if subseq_match_ci(body, needle).is_none() {
-            return false;
+        if let Some((from, to)) = &needle.due_range {
+            match t.due.as_deref() {
+                Some(d) if d >= from.as_str() && d <= to.as_str() => {}
+                _ => return false,
+            }
+        }
+        if !needle.text.is_empty() {
+            let body = todo::body_after_priority(&t.raw);
+            if subseq_match_ci(body, &needle.text).is_none() {
+                return false;
+            }
         }
     }
     true
+}
+
+/// Pull the first parseable `due:` term out of `needle`, if any, returning
+/// the remaining text plus the resolved `(from, to)` range. An unparseable
+/// `due:` term is left in place as literal text. `None` when nothing parses,
+/// so callers with no `due:` usage see unchanged matching behavior.
+fn extract_due_range(needle: &str, today: &str) -> Option<(String, (String, String))> {
+    let today_date = NaiveDate::parse_from_str(today, "%Y-%m-%d").ok()?;
+    let mut found = None;
+    let mut rest: Vec<&str> = Vec::new();
+    for term in needle.split_whitespace() {
+        if found.is_none()
+            && let Some(value) = term.strip_prefix("due:")
+            && let Some(range) = due_filter::parse_due_range(value, today_date)
+        {
+            found = Some(range);
+            continue;
+        }
+        rest.push(term);
+    }
+    found.map(|range| (rest.join(" "), range))
 }
 
 pub fn list_predicate(
@@ -113,7 +176,7 @@ pub fn list_predicate(
     show_future: bool,
     today: &str,
     filter: &Filter,
-    needle: Option<&str>,
+    needle: Option<&ResolvedNeedle>,
 ) -> bool {
     if t.done && !show_done {
         return false;
@@ -207,6 +270,98 @@ mod tests {
         let tasks = crate::todo::parse_file(raw);
         let projects = unique_values(&tasks, |t| &t.projects);
         assert_eq!(projects, vec!["health".to_string(), "work".to_string()]);
+    }
+
+    fn resolved(needle: &str, today: &str) -> ResolvedNeedle {
+        resolve_needle(needle, today)
+    }
+
+    #[test]
+    fn due_exact_date_matches_structurally() {
+        let raw = "buy milk due:2026-08-01\nbuy eggs due:2026-08-02\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:2026-08-01", "2026-07-28");
+        assert!(passes_user_filter(&tasks[0], &filter, Some(&needle)));
+        assert!(!passes_user_filter(&tasks[1], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn due_plus_range_matches_within_window() {
+        let raw = "today due:2026-07-28\nin range due:2026-08-04\nout of range due:2026-08-05\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:+1w", "2026-07-28");
+        for t in &tasks[..2] {
+            assert!(passes_user_filter(t, &filter, Some(&needle)));
+        }
+        assert!(!passes_user_filter(&tasks[2], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn due_minus_range_matches_past_window() {
+        let raw = "recent due:2026-07-25\ntoday due:2026-07-28\ntoo old due:2026-07-24\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:-3d", "2026-07-28");
+        for t in &tasks[..2] {
+            assert!(passes_user_filter(t, &filter, Some(&needle)));
+        }
+        assert!(!passes_user_filter(&tasks[2], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn due_term_with_no_task_due_date_never_matches() {
+        let raw = "no due date at all\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:+1w", "2026-07-28");
+        assert!(!passes_user_filter(&tasks[0], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn invalid_due_term_falls_back_to_literal_search() {
+        let raw = "note due:xyz reminder\nunrelated task\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:xyz", "2026-07-28");
+        assert!(passes_user_filter(&tasks[0], &filter, Some(&needle)));
+        assert!(!passes_user_filter(&tasks[1], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn second_due_term_falls_back_to_literal_text() {
+        // Only the first `due:` term is honored; the second is literal text,
+        // so a match here only happens to work because "2026-07-31 do"
+        // spells out a `due:-3d` subsequence.
+        let raw = "due:2026-07-31 do it\ndue:2026-08-01 other task\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:+1w due:-3d", "2026-07-28");
+        assert!(passes_user_filter(&tasks[0], &filter, Some(&needle)));
+        assert!(!passes_user_filter(&tasks[1], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn malformed_task_due_value_compares_lexicographically() {
+        // `due:` isn't validated as a real date — the range check is a plain
+        // string compare, same as `due_bucket`/`cmp_due`.
+        let raw = "garbage due:tbd\nin range due:2026-08-01\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:+1w", "2026-07-28");
+        assert!(!passes_user_filter(&tasks[0], &filter, Some(&needle)));
+        assert!(passes_user_filter(&tasks[1], &filter, Some(&needle)));
+    }
+
+    #[test]
+    fn due_term_combined_with_free_text() {
+        let raw = "buy groceries due:2026-08-01\nbuy stamps due:2026-08-01\n";
+        let tasks = crate::todo::parse_file(raw);
+        let filter = Filter::default();
+        let needle = resolved("due:+1w groceries", "2026-07-28");
+        assert!(passes_user_filter(&tasks[0], &filter, Some(&needle)));
+        assert!(!passes_user_filter(&tasks[1], &filter, Some(&needle)));
     }
 
     #[test]

--- a/src/due_filter.rs
+++ b/src/due_filter.rs
@@ -1,0 +1,117 @@
+//! Parsing for `due:` filter terms.
+//!
+//! Extends `due:` filtering beyond an exact `YYYY-MM-DD` match to ranges
+//! anchored on today, reusing the `t:` threshold grammar (see
+//! [`crate::threshold`]) so `due:` and `t:` offsets mean the same thing:
+//!
+//! ```text
+//! due:YYYY-MM-DD   // exact match — a single-day range
+//! due:[+-]?Nu       // range from today to the offset, u ∈ {d, w, m, b}
+//! ```
+//!
+//! `due:+1w` matches tasks due between today and 7 days from now
+//! (inclusive). `due:-3d` matches tasks due between 3 days ago and today.
+//! No sign defaults to `+` (forward), matching `t:`'s convention.
+
+use chrono::NaiveDate;
+
+use crate::threshold::{self, ThresholdSpec};
+
+/// Parse the *value* of a `due:` filter term (e.g. `"2026-08-01"`, `"+1w"`,
+/// `"-3d"`) into an inclusive `(from, to)` ISO-date range to compare against
+/// a task's `due:` field. An absolute date becomes a single-day range.
+/// Returns `None` for unrecognized forms — callers fall back to treating the
+/// term as literal search text.
+pub fn parse_due_range(value: &str, today: NaiveDate) -> Option<(String, String)> {
+    let spec = threshold::parse_threshold(value)?;
+    match spec {
+        ThresholdSpec::Absolute(d) => {
+            let s = iso(d);
+            Some((s.clone(), s))
+        }
+        ThresholdSpec::Relative { before, .. } => {
+            let bound = threshold::resolve_at(&spec, today)?;
+            let (from, to) = if before {
+                (bound, today)
+            } else {
+                (today, bound)
+            };
+            debug_assert!(from <= to, "due-range bound computed out of order");
+            Some((iso(from), iso(to)))
+        }
+    }
+}
+
+fn iso(d: NaiveDate) -> String {
+    d.format("%Y-%m-%d").to_string()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn d(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
+    }
+
+    #[test]
+    fn absolute_date_is_single_day_range() {
+        assert_eq!(
+            parse_due_range("2026-08-01", d("2026-07-28")),
+            Some(("2026-08-01".to_string(), "2026-08-01".to_string()))
+        );
+    }
+
+    #[test]
+    fn plus_offset_ranges_forward_from_today() {
+        assert_eq!(
+            parse_due_range("+1w", d("2026-07-28")),
+            Some(("2026-07-28".to_string(), "2026-08-04".to_string()))
+        );
+    }
+
+    #[test]
+    fn bare_offset_defaults_forward() {
+        assert_eq!(
+            parse_due_range("7d", d("2026-07-28")),
+            Some(("2026-07-28".to_string(), "2026-08-04".to_string()))
+        );
+    }
+
+    #[test]
+    fn minus_offset_ranges_backward_from_today() {
+        assert_eq!(
+            parse_due_range("-3d", d("2026-07-28")),
+            Some(("2026-07-25".to_string(), "2026-07-28".to_string()))
+        );
+    }
+
+    #[test]
+    fn month_offset_clamps_at_month_end() {
+        // Mar 31 - 1m -> Feb 28 (non-leap year), same clamping as `t:`.
+        assert_eq!(
+            parse_due_range("-1m", d("2026-03-31")),
+            Some(("2026-02-28".to_string(), "2026-03-31".to_string()))
+        );
+    }
+
+    #[test]
+    fn business_day_offset_skips_weekends() {
+        // Fri 2026-07-31 + 1b -> Mon 2026-08-03 (skip Sat/Sun).
+        assert_eq!(
+            parse_due_range("1b", d("2026-07-31")),
+            Some(("2026-07-31".to_string(), "2026-08-03".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_forms() {
+        for bad in ["", "abc", "1y", "1.5d", "d", "-", "+", "1z"] {
+            assert!(
+                parse_due_range(bad, d("2026-07-28")).is_none(),
+                "expected None for {bad:?}"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cmd;
 pub mod config;
 pub mod config_watcher;
 pub mod core;
+pub mod due_filter;
 pub mod inbox;
 pub mod keybinds;
 pub mod nl;

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -22,6 +22,14 @@ use chrono::{Datelike, Days, Months, NaiveDate, Weekday};
 
 use crate::recurrence::RecUnit;
 
+/// Business-day offsets beyond this are rejected by `parse_relative` rather
+/// than parsed. `advance_business`/`retreat_business` walk one calendar day
+/// at a time, so an unbounded `n` (e.g. `t:4000000000b`) turns a single parse
+/// into a multi-minute loop; this caps it (~1600 years of business days) far
+/// above anything a real threshold or `due:` range would use, while keeping
+/// the loop itself simple and correct for every start weekday.
+const MAX_BUSINESS_DAY_OFFSET: u32 = 500_000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThresholdSpec {
     Absolute(NaiveDate),
@@ -74,6 +82,9 @@ fn parse_relative(value: &str) -> Option<ThresholdSpec> {
         // Year deliberately omitted from the threshold grammar.
         _ => return None,
     };
+    if unit == RecUnit::BusinessDay && n > MAX_BUSINESS_DAY_OFFSET {
+        return None;
+    }
     Some(ThresholdSpec::Relative { before, n, unit })
 }
 
@@ -88,11 +99,23 @@ pub fn resolve(
 ) -> Option<NaiveDate> {
     match *spec {
         ThresholdSpec::Absolute(d) => Some(d),
-        ThresholdSpec::Relative { before, n, unit } => {
+        ThresholdSpec::Relative { .. } => {
             let anchor_str = due.or(created)?;
             let anchor = NaiveDate::parse_from_str(anchor_str, "%Y-%m-%d").ok()?;
-            shift(anchor, n, unit, before)
+            resolve_at(spec, anchor)
         }
+    }
+}
+
+/// Resolve `spec` against an explicit `anchor`, skipping `resolve`'s
+/// due-then-created anchor selection. The sanctioned entry point for callers
+/// (e.g. [`crate::due_filter`]) that already have their anchor in hand and
+/// don't need `t:`'s due/created fallback — `shift` itself stays private so
+/// `resolve`/`resolve_at` remain the only ways to turn a spec into a date.
+pub(crate) fn resolve_at(spec: &ThresholdSpec, anchor: NaiveDate) -> Option<NaiveDate> {
+    match *spec {
+        ThresholdSpec::Absolute(d) => Some(d),
+        ThresholdSpec::Relative { before, n, unit } => shift(anchor, n, unit, before),
     }
 }
 
@@ -269,6 +292,14 @@ mod tests {
                 unit: RecUnit::BusinessDay,
             }
         );
+    }
+
+    #[test]
+    fn rejects_implausibly_large_business_day_offset() {
+        // Business-day arithmetic walks one calendar day at a time; without a
+        // cap this would loop billions of times on a single parse.
+        assert!(parse_threshold("500001b").is_none());
+        assert!(parse_threshold("500000b").is_some());
     }
 
     #[test]

--- a/src/ui/filters.rs
+++ b/src/ui/filters.rs
@@ -4,10 +4,9 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::app::{App, ordered_unique};
-use crate::search::subseq_match_ci;
+use crate::app::{App, Filter, ordered_unique};
+use crate::core::filter;
 use crate::theme::Theme;
-use crate::todo;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let theme = app.theme();
@@ -73,14 +72,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                     .add_modifier(Modifier::BOLD),
             )],
         ));
+        let today = app.today();
+        let default_filter = Filter::default();
         for f in saved {
             let active = app.filter().search == f.query;
+            // Same predicate the list view uses, so a saved `due:` query
+            // counts by date range instead of its own literal text.
+            let needle = filter::resolve_needle(&f.query, today);
             let count = app
                 .tasks()
                 .iter()
                 .filter(|t| {
-                    !t.done
-                        && subseq_match_ci(todo::body_after_priority(&t.raw), &f.query).is_some()
+                    !t.done && filter::passes_user_filter(t, &default_filter, Some(&needle))
                 })
                 .count();
             lines.push(filter_row(theme, "", &f.name, count, active, theme.accent));

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -75,7 +75,7 @@ const FORMAT: Section = (
         ("YYYY-MM-DD", "creation / done date"),
         ("+project", "project tag(s)"),
         ("@context", "context tag(s)"),
-        ("due:YYYY-MM-DD", "due date"),
+        ("due:YYYY-MM-DD", "due date (+1w = range)"),
         ("rec:Nu", "recur (u in d/w/m/y/b)"),
         ("rec:+Nu", "strict: anchor on due:"),
         ("x DATE BODY", "completed task prefix"),

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::{App, GroupKey, ListDueBucket, Mode, View};
+use crate::core::filter;
 use crate::theme::Theme;
 use crate::ui::{header, keep_cursor_visible, task_row};
 
@@ -38,6 +39,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         crate::ui::empty::render(frame, body_area, app);
         return;
     }
+
+    // Highlight only the free-text part — a `due:` term filters by date and
+    // never appears verbatim in the body.
+    let resolved_needle = (!app.filter.search.is_empty())
+        .then(|| filter::resolve_needle(&app.filter.search, app.today()));
+    let match_term: Option<&str> = resolved_needle
+        .as_ref()
+        .and_then(|n| (!n.text.is_empty()).then_some(n.text.as_str()));
 
     let visible = app.visible_indices();
     let groups = app.visible_groups();
@@ -75,11 +84,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 multi_checked: app.selection.is_selected(abs),
                 selected: app.selection.is_selected(abs),
                 show_line_num: app.prefs.layout.line_num,
-                match_term: if app.filter.search.is_empty() {
-                    None
-                } else {
-                    Some(&app.filter.search)
-                },
+                match_term,
                 today: app.today(),
                 hidden_keys: &app.prefs.hidden_keys,
             };

--- a/tests/snapshots/snapshots__help_overlay_styled.snap
+++ b/tests/snapshots/snapshots__help_overlay_styled.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshots.rs
+assertion_line: 227
 expression: buffer_to_styled(&buf)
 ---
 {fg=#6b7280 bg=#1f232b mod=bold} FILTERS{/}{fg=#c8ccd4 bg=#1f232b}                  {/}{bg=#1f232b} {/}{fg=#8aa9c9 bg=#1f232b}▶{/}{fg=#e07a7a bg=#1f232b}▮{/}{fg=#8aa9c9 bg=#1f232b}◀{/}{bg=#1f232b} {/}{fg=#c8ccd4 bg=#1f232b mod=bold}/tmp/tuxedo-snapshot.txt{/}{fg=#6b7280 bg=#1f232b}  •  15 tas{/}{fg=#6b7280 bg=#1f232b mod=bold} DETAIL{/}{fg=#c8ccd4 bg=#1f232b}                           {/}
@@ -27,7 +28,7 @@ expression: buffer_to_styled(&buf)
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}                                                {/}{fg=#c89a6e bg=#1f232b mod=bold}q                 {/}{fg=#c8ccd4 bg=#1f232b}quit                  {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│────────────────────────────────────────────────────────────────────────────────────────│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}  {/}{fg=#8aa9c9 bg=#1f232b mod=bold}FORMAT{/}{fg=#c8ccd4 bg=#1f232b}                                                                                {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
-{fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}    {/}{fg=#c89a6e bg=#1f232b mod=bold}(A)               {/}{fg=#c8ccd4 bg=#1f232b}priority A-Z              {/}{fg=#c89a6e bg=#1f232b mod=bold}due:YYYY-MM-DD    {/}{fg=#c8ccd4 bg=#1f232b}due date              {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
+{fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}    {/}{fg=#c89a6e bg=#1f232b mod=bold}(A)               {/}{fg=#c8ccd4 bg=#1f232b}priority A-Z              {/}{fg=#c89a6e bg=#1f232b mod=bold}due:YYYY-MM-DD    {/}{fg=#c8ccd4 bg=#1f232b}due date (+1w = range){/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}    {/}{fg=#c89a6e bg=#1f232b mod=bold}YYYY-MM-DD        {/}{fg=#c8ccd4 bg=#1f232b}creation / done date      {/}{fg=#c89a6e bg=#1f232b mod=bold}rec:Nu            {/}{fg=#c8ccd4 bg=#1f232b}recur (u in d/w/m/y/b){/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}    {/}{fg=#c89a6e bg=#1f232b mod=bold}+project          {/}{fg=#c8ccd4 bg=#1f232b}project tag(s)            {/}{fg=#c89a6e bg=#1f232b mod=bold}rec:+Nu           {/}{fg=#c8ccd4 bg=#1f232b}strict: anchor on due:{/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}
 {fg=#c8ccd4 bg=#1f232b}     {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}    {/}{fg=#c89a6e bg=#1f232b mod=bold}@context          {/}{fg=#c8ccd4 bg=#1f232b}context tag(s)            {/}{fg=#c89a6e bg=#1f232b mod=bold}x DATE BODY       {/}{fg=#c8ccd4 bg=#1f232b}completed task prefix {/}{fg=#2a2f38 bg=#1f232b}│{/}{fg=#c8ccd4 bg=#1f232b}     {/}

--- a/tests/snapshots/snapshots__help_overlay_text.snap
+++ b/tests/snapshots/snapshots__help_overlay_text.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/snapshots.rs
+assertion_line: 226
 expression: buffer_to_text(&buf)
 ---
  FILTERS                   ▶▮◀ /tmp/tuxedo-snapshot.txt  •  15 tas DETAIL                           
@@ -27,7 +28,7 @@ expression: buffer_to_text(&buf)
      │                                                q                 quit                  │     
      │────────────────────────────────────────────────────────────────────────────────────────│     
      │  FORMAT                                                                                │     
-     │    (A)               priority A-Z              due:YYYY-MM-DD    due date              │     
+     │    (A)               priority A-Z              due:YYYY-MM-DD    due date (+1w = range)│     
      │    YYYY-MM-DD        creation / done date      rec:Nu            recur (u in d/w/m/y/b)│     
      │    +project          project tag(s)            rec:+Nu           strict: anchor on due:│     
      │    @context          context tag(s)            x DATE BODY       completed task prefix │     

--- a/todo.txt
+++ b/todo.txt
@@ -1,7 +1,7 @@
-(C) 2026-05-07 Calendar week strip view with reschedule keys +tuxedo @dev
-(B) 2026-05-07 Hook scripts for pre and post add complete and delete events +tuxedo @dev
-(B) 2026-05-11 Natural-language relative dates in due and threshold fields tomorrow fri plus3d eom +tuxedo @dev
-(B) 2026-05-11 Snooze and postpone keys to bump due by day week month with bulk support +tuxedo @dev
+(C) 2026-05-07 Calendar week strip view with reschedule keys +tuxedo @dev due:2026-07-29
+(B) 2026-05-07 Hook scripts for pre and post add complete and delete events +tuxedo @dev due:2026-07-30
+(B) 2026-05-11 Natural-language relative dates in due and threshold fields tomorrow fri plus3d eom +tuxedo @dev due:2026-08-03
+(B) 2026-05-11 Snooze and postpone keys to bump due by day week month with bulk support +tuxedo @dev due:2026-08-18
 (C) 2026-05-11 Multi-file workspace config and quick file switcher +tuxedo @dev
 (C) 2026-05-11 Inbox capture mode and separate triage review mode +tuxedo @dev
 (C) 2026-05-11 Repeat-last-action dot key and saved filter marks +tuxedo @dev


### PR DESCRIPTION
This adds the ability to filter tasks by a date range using the familiar `[+-]Nu` syntax that is already used for setting dates.

Filter terms will parse out `due:[+-]Nu` from the search term and rejoin the remaining text to be matched against the task body itself. The `due:[+-]Nu` field will be used to filter the task list to tasks that are due within the provided range.