### PR TITLE
feat: Prefill new tasks with current filters to avoid retyping them a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ The modal keys below apply in Normal mode:
 | `o` | open the current task's existing `note:<path>` in `$VISUAL` / `$EDITOR` |
 | `O` | create the current task's note if needed, then open it |
 
+While a `+project` or `@context` filter is active, `n` seeds the add prompt
+with the matching tags so a task added under a filter stays in view —
+backspace to drop them. A `/`-search filter seeds nothing.
+
 ### Layout & theme
 
 | Key | Action |

--- a/src/app/mutations.rs
+++ b/src/app/mutations.rs
@@ -59,7 +59,11 @@ impl App {
 
     pub fn add_from_draft(&mut self) -> AddOutcome {
         let text = self.draft.text().trim().to_string();
-        if text.is_empty() {
+        // A draft still holding nothing but the filter seed carries no task —
+        // treat it as empty so `n` + Enter under a filter stays the silent
+        // no-op it is without one. Inert when nothing is filtered: `tag_seed`
+        // is empty and `text` is already known not to be.
+        if text.is_empty() || text == self.filter.tag_seed().trim_end() {
             return AddOutcome::Empty;
         }
 
@@ -463,6 +467,29 @@ mod tests {
         assert_eq!(app.tasks().len(), 1);
         assert!(app.tasks()[0].raw.ends_with("Buy milk"));
         assert_eq!(app.flash_active(), Some("added"));
+    }
+
+    #[test]
+    fn add_from_draft_ignores_untouched_filter_seed() {
+        let mut app = build_app("a +work\n");
+        app.set_project_filter(Some("work".to_string()));
+        app.draft_set(app.filter().tag_seed());
+        let outcome = app.add_from_draft();
+        assert_eq!(outcome, crate::app::AddOutcome::Empty);
+        assert_eq!(app.tasks().len(), 1, "no bodyless +work task may be saved");
+        assert_eq!(app.flash_active(), None, "the no-op must stay silent");
+    }
+
+    #[test]
+    fn add_from_draft_saves_a_body_typed_after_the_seed() {
+        let mut app = build_app("a +work\n");
+        app.set_project_filter(Some("work".to_string()));
+        app.draft_set(format!("{}Buy milk", app.filter().tag_seed()));
+        let outcome = app.add_from_draft();
+        assert_eq!(outcome, crate::app::AddOutcome::Saved);
+        assert_eq!(app.tasks().len(), 2);
+        assert_eq!(app.tasks()[1].projects, vec!["work"]);
+        assert!(app.tasks()[1].raw.ends_with("+work Buy milk"));
     }
 
     #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -147,6 +147,16 @@ impl Filter {
         self.project.is_some() || self.context.is_some() || !self.search.is_empty()
     }
 
+    /// The active `+project` / `@context` tags as an add-prompt prefix, with
+    /// a trailing space; empty when neither is set. A task added under a
+    /// filter that doesn't carry its tags drops out of the view the moment it
+    /// saves. `search` contributes nothing — it is a needle, not a tag.
+    pub fn tag_seed(&self) -> String {
+        let project = self.project.as_deref().map(|p| format!("+{p} "));
+        let context = self.context.as_deref().map(|c| format!("@{c} "));
+        project.unwrap_or_default() + &context.unwrap_or_default()
+    }
+
     /// Drop every filter component back to its empty state.
     pub fn clear(&mut self) {
         self.project = None;
@@ -162,4 +172,38 @@ impl Filter {
 pub struct SavedFilter {
     pub name: String,
     pub query: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Filter;
+
+    #[test]
+    fn tag_seed_is_empty_without_project_or_context() {
+        let filter = Filter {
+            search: "milk".to_string(),
+            ..Filter::default()
+        };
+        assert_eq!(filter.tag_seed(), "", "a search needle is not a tag");
+    }
+
+    #[test]
+    fn tag_seed_leads_with_project_then_context() {
+        let filter = Filter {
+            project: Some("work".to_string()),
+            context: Some("home".to_string()),
+            search: String::new(),
+        };
+        // Trailing space: the seed is a prefix the body gets typed after.
+        assert_eq!(filter.tag_seed(), "+work @home ");
+    }
+
+    #[test]
+    fn tag_seed_covers_a_single_active_filter() {
+        let filter = Filter {
+            context: Some("home".to_string()),
+            ..Filter::default()
+        };
+        assert_eq!(filter.tag_seed(), "@home ");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1099,7 +1099,12 @@ fn apply_action(app: &mut App, action: Action) {
         Action::HalfPageUp => app.cursor = app.cursor.saturating_sub(10),
         Action::BeginAdd => {
             app.mode = Mode::Insert;
-            app.draft_clear();
+            // Seed from the active filter: a task added under `+work` almost
+            // always belongs to it, and without the tag it drops out of the
+            // view the moment it saves. The cursor parks after the seed, so
+            // an unwanted tag is a backspace away.
+            let seed = app.filter().tag_seed();
+            app.draft_set_insert(seed);
             app.selection.exit_edit();
         }
         Action::BeginEdit => {
@@ -1704,6 +1709,34 @@ mod tests {
         assert!(app.draft.overlay().is_none());
         let task = app.tasks().last().expect("task added");
         assert_eq!(task.due.as_deref(), Some("2026-06-07"));
+    }
+
+    #[test]
+    fn begin_add_seeds_draft_from_active_filter() {
+        let mut app = build_app();
+        app.set_project_filter(Some("work".to_string()));
+        app.set_context_filter(Some("home".to_string()));
+        apply_action(&mut app, Action::BeginAdd);
+        assert_eq!(app.mode, Mode::Insert);
+        assert_eq!(app.draft.text(), "+work @home ");
+        assert_eq!(
+            app.draft.cursor(),
+            "+work @home ".len(),
+            "cursor parks after the seed so the body types straight in"
+        );
+        for c in "Buy milk".chars() {
+            app.draft_insert_char(c);
+        }
+        assert_eq!(app.draft.text(), "+work @home Buy milk");
+    }
+
+    #[test]
+    fn begin_add_leaves_draft_empty_without_a_filter() {
+        let mut app = build_app();
+        apply_action(&mut app, Action::BeginAdd);
+        assert_eq!(app.mode, Mode::Insert);
+        assert_eq!(app.draft.text(), "");
+        assert_eq!(app.draft.cursor(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## What

With a `+project` or `@context` filter active, `n` opens the add prompt pre-typed with those tags and the cursor after them, instead of on an empty buffer.

```
fp -> +work, fc -> @home

n  ->  | > +work @home _ |

type "buy milk"  ->  2026-08-07 +work @home buy milk
```

With no filter active the prompt opens empty, exactly as before.

## Why

A task added while a filter is up almost always belongs to that filter, but the prompt made you retype the tag every time. Forgetting was the real cost: the new task immediately dropped out of the view you were working in.

## How

`Filter::tag_seed()` renders the active project and context as a prefix, and `Action::BeginAdd` seeds the draft with it through the existing `draft_set_insert`. No new `DraftState` API, no new action, no config surface.

`add_from_draft` treats a draft still holding nothing but the seed as empty, so `n` followed straight by Enter stays the silent no-op it is today rather than saving a bodyless `+work` line.

`search` seeds nothing, since it is a subsequence needle rather than a tag.

## Notes

Leading tags put the cursor where you type and make an unwanted tag a backspace away, but they are the reverse of the body-then-tags order `nl::format_as_todo_txt` and `Task::add_project` produce. Trailing instead is a small change if you prefer it.

Shipped unconditional rather than behind a config flag, since every bool in `config.toml` today is persisted view state. Happy to gate it.

`mise run fmt clippy test` all pass, with no snapshot changes.

Closes #125 