### PR TITLE
feat: add mouse support (select, scroll, filter toggling)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,8 +1,10 @@
 use core::fmt;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::mpsc::{Receiver, TryRecvError};
+
+use ratatui::layout::Rect;
 
 use crate::config::Config;
 use crate::core::Store;
@@ -46,8 +48,8 @@ pub use palette::CommandPaletteState;
 pub use prefs::{Layout, Prefs};
 pub use selection::Selection;
 pub use types::{
-    AUTOCOMPLETE_CAP, AddOutcome, Density, FLASH_TTL, Filter, LEADER_WINDOW, Mode, SavedFilter,
-    Sort, UNDO_LIMIT, View,
+    AUTOCOMPLETE_CAP, AddOutcome, Density, FLASH_TTL, Filter, FilterTarget, LEADER_WINDOW, Mode,
+    SavedFilter, Sort, UNDO_LIMIT, View,
 };
 pub use visibility::GroupKey;
 
@@ -144,6 +146,29 @@ pub struct App {
     /// view, keyed by `View::idx()`. Updated at render time via `Cell` so the
     /// renderer can keep the cursor row visible without taking `&mut self`.
     pub(crate) view_scroll: [Cell<u16>; 2],
+    /// Screen rect of the last-rendered task-list body for the view at
+    /// `View::idx()`. Set at render time via `Cell` (same pattern as
+    /// `view_scroll`) so a later mouse click can be tested against where
+    /// rows actually landed on screen.
+    pub(crate) view_body_rect: [Cell<Rect>; 2],
+    /// Sparse `(rendered line, cursor index)` pairs recorded for the last
+    /// render of each view, keyed by `View::idx()`. Only lines that are
+    /// task rows appear — blank/group-header lines are absent. Mouse click
+    /// handling looks up the clicked line here to find which task it hit.
+    pub(crate) view_row_index: [RefCell<Vec<(usize, usize)>>; 2],
+    /// Screen rect of the last-rendered left sidebar (filters list), for
+    /// mapping a click back to the project/context row it landed on.
+    pub(crate) filters_rect: Cell<Rect>,
+    /// Sparse `(rendered line, target)` pairs for the sidebar's filter rows
+    /// — only project/context row lines appear. The sidebar doesn't scroll,
+    /// so a line index is directly a row offset from `filters_rect.y`.
+    pub(crate) filters_row_index: RefCell<Vec<(usize, FilterTarget)>>,
+    /// Screen rect of the last-rendered detail pane (right sidebar).
+    pub(crate) detail_rect: Cell<Rect>,
+    /// `(line, col_start, col_end, target)` for each `+project`/`@context`
+    /// token in the detail pane's last render, so a click on the token text
+    /// (not just its row) can be resolved back to a filter target.
+    pub(crate) detail_token_index: RefCell<Vec<(usize, u16, u16, FilterTarget)>>,
     /// Handle to the in-TUI capture server. `None` until the first time
     /// the user presses `s` (or invokes "show capture QR" from the
     /// palette). Once bound, the entry stays for the rest of the
@@ -215,6 +240,12 @@ impl App {
             saved_pick_idx: 0,
             command_palette: CommandPaletteState::default(),
             view_scroll: [Cell::new(0), Cell::new(0)],
+            view_body_rect: [Cell::new(Rect::default()), Cell::new(Rect::default())],
+            view_row_index: [RefCell::new(Vec::new()), RefCell::new(Vec::new())],
+            filters_rect: Cell::new(Rect::default()),
+            filters_row_index: RefCell::new(Vec::new()),
+            detail_rect: Cell::new(Rect::default()),
+            detail_token_index: RefCell::new(Vec::new()),
             share: None,
             notes_dir: note_dir,
             pending_editor_path: None,
@@ -503,6 +534,90 @@ impl App {
     /// Active top-level view (List/Archive).
     pub fn view(&self) -> View {
         self.view
+    }
+
+    /// Map a terminal cell to the visible-list cursor index it landed on,
+    /// using the body rect and line map captured during the current view's
+    /// last render. `None` when the cell falls outside the list body or on a
+    /// blank/group-header line.
+    pub fn row_at(&self, col: u16, row: u16) -> Option<usize> {
+        let idx = self.view.idx();
+        let rect = self.view_body_rect[idx].get();
+        if col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height
+        {
+            return None;
+        }
+        let scroll = self.view_scroll[idx].get() as usize;
+        let line = scroll + (row - rect.y) as usize;
+        self.view_row_index[idx]
+            .borrow()
+            .iter()
+            .find(|&&(l, _)| l == line)
+            .map(|&(_, i)| i)
+    }
+
+    /// Map a terminal cell to the project/context row it landed on in the
+    /// left sidebar's filter list, using the rect and line map captured
+    /// during the sidebar's last render. `None` outside the sidebar body or
+    /// on a non-row line (section header, blank, hint).
+    pub fn filter_target_at(&self, col: u16, row: u16) -> Option<FilterTarget> {
+        let rect = self.filters_rect.get();
+        if col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height
+        {
+            return None;
+        }
+        // The sidebar renders as one unscrolled Paragraph, so the line index
+        // is just the row offset from the rect's top.
+        let line = (row - rect.y) as usize;
+        self.filters_row_index
+            .borrow()
+            .iter()
+            .find(|(l, _)| *l == line)
+            .map(|(_, target)| target.clone())
+    }
+
+    /// Map a terminal cell to the `+project`/`@context` token it landed on
+    /// in the detail pane, using the token map captured during the pane's
+    /// last render. `None` outside the pane or between/outside token spans.
+    pub fn detail_target_at(&self, col: u16, row: u16) -> Option<FilterTarget> {
+        let rect = self.detail_rect.get();
+        if col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height
+        {
+            return None;
+        }
+        let line = (row - rect.y) as usize;
+        let rel_col = col - rect.x;
+        self.detail_token_index
+            .borrow()
+            .iter()
+            .find(|(l, start, end, _)| *l == line && rel_col >= *start && rel_col < *end)
+            .map(|(_, _, _, target)| target.clone())
+    }
+
+    /// Screen rect of the last-rendered detail pane, if it was on screen.
+    pub fn detail_rect(&self) -> Rect {
+        self.detail_rect.get()
+    }
+
+    /// Apply `target`'s filter if it isn't already active, otherwise clear
+    /// it.The toggle behind both sidebar and detail-pane filter clicks.
+    pub fn toggle_filter_target(&mut self, target: FilterTarget) {
+        match target {
+            FilterTarget::Project(name) => {
+                if self.filter.project.as_deref() == Some(name.as_str()) {
+                    self.set_project_filter(None);
+                } else {
+                    self.set_project_filter(Some(name));
+                }
+            }
+            FilterTarget::Context(name) => {
+                if self.filter.context.as_deref() == Some(name.as_str()) {
+                    self.set_context_filter(None);
+                } else {
+                    self.set_context_filter(Some(name));
+                }
+            }
+        }
     }
 
     /// Switch top-level view. Recomputes the cache so the next frame reflects

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -66,6 +66,15 @@ impl View {
     }
 }
 
+/// A project or context a mouse click landed on, in the sidebar's filter
+/// list or the detail pane's `+project`/`@context` tokens. Both surfaces
+/// resolve a click to one of these and hand it to the same toggle logic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterTarget {
+    Project(String),
+    Context(String),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Sort {
     Priority,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use ratatui::DefaultTerminal;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
 
 use std::io::Write;
 
@@ -110,12 +113,19 @@ fn main() -> Result<()> {
     }
 
     let terminal = ratatui::init();
+    let default_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::execute!(io::stdout(), event::DisableMouseCapture);
+        default_panic_hook(info);
+    }));
+    let _ = crossterm::execute!(io::stdout(), event::EnableMouseCapture);
     // Give the window/tab a consistent `tuxedo <path>` title across terminals
     // and operating systems, shortening long paths to fit a fixed budget.
     let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
     let title = ui::title::terminal_title(&path, home.as_deref(), ui::title::DEFAULT_BUDGET);
     let _ = crossterm::execute!(io::stdout(), crossterm::terminal::SetTitle(title));
     let result = run(terminal, &mut app_state, &keybinds, config_rx);
+    let _ = crossterm::execute!(io::stdout(), event::DisableMouseCapture);
     ratatui::restore();
     // Clear the title on exit so the shell retitles on its next prompt rather
     // than leaving `tuxedo …` behind.
@@ -237,6 +247,10 @@ fn run(
                 Event::Resize(_, _) => {
                     dirty = true;
                 }
+                Event::Mouse(mouse) => {
+                    handle_mouse(app, mouse);
+                    dirty = true;
+                }
                 _ => {}
             }
         } else if !app.check_external_changes() {
@@ -296,6 +310,9 @@ fn open_path_in_editor(path: &std::path::Path) -> Result<()> {
     let editor = std::env::var("VISUAL")
         .or_else(|_| std::env::var("EDITOR"))
         .unwrap_or_else(|_| "nvim".to_string());
+    // Mouse capture must drop before the editor takes the terminal, or its
+    // clicks arrive as raw escape codes instead of normal editor input.
+    let _ = crossterm::execute!(io::stdout(), event::DisableMouseCapture);
     ratatui::restore();
     let status = std::process::Command::new(&editor)
         .arg(path)
@@ -306,6 +323,7 @@ fn open_path_in_editor(path: &std::path::Path) -> Result<()> {
         io::stdout(),
         ratatui::crossterm::terminal::EnterAlternateScreen
     )?;
+    let _ = crossterm::execute!(io::stdout(), event::EnableMouseCapture);
     match status {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
@@ -354,6 +372,33 @@ fn handle_key(app: &mut App, key: KeyEvent, keybinds: &KeyBindings) {
         Mode::Welcome => handle_welcome(app, key),
         Mode::Normal | Mode::Visual => handle_normal(app, key, keybinds),
     }
+}
+
+/// Handles mouse input: clicking a task row moves the cursor there,
+/// clicking a project/context in the sidebar or a `+project`/`@context`
+/// token in the detail pane toggles that filter, and the scroll wheel
+/// moves the cursor up/down like `j`/`k`.
+/// Ignored outside Normal/Visual.
+fn handle_mouse(app: &mut App, mouse: MouseEvent) {
+    if !matches!(app.mode, Mode::Normal | Mode::Visual) {
+        return;
+    }
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if let Some(target) = app
+                .filter_target_at(mouse.column, mouse.row)
+                .or_else(|| app.detail_target_at(mouse.column, mouse.row))
+            {
+                app.toggle_filter_target(target);
+            } else if let Some(i) = app.row_at(mouse.column, mouse.row) {
+                app.cursor = i;
+            }
+        }
+        MouseEventKind::ScrollDown => app.cursor = app.cursor.saturating_add(1),
+        MouseEventKind::ScrollUp => app.cursor = app.cursor.saturating_sub(1),
+        _ => {}
+    }
+    app.clamp_cursor();
 }
 
 /// First-run welcome prompt. `c` creates `./todo.txt` (the App's current
@@ -1414,7 +1459,7 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use tuxedo::app::Sort;
+    use tuxedo::app::{Density, Sort};
     use tuxedo::config::Config;
 
     fn key(c: char) -> KeyEvent {
@@ -2313,5 +2358,268 @@ mod tests {
         app.set_search("abc".into());
         handle_search(&mut app, ctrl('u'));
         assert_eq!(app.draft.text(), "");
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn render_for_mouse_test(app: &App) {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(40, 20)).expect("test backend");
+        terminal
+            .draw(|f| ui::draw(f, app))
+            .expect("render for mouse test");
+    }
+    fn build_app_for_mouse() -> App {
+        let mut app = build_app();
+        app.prefs.sort = Sort::File;
+        app.prefs.density = Density::Compact;
+        app.prefs.layout.left = false;
+        app.prefs.layout.right = false;
+        app.recompute_visible();
+        app
+    }
+
+    #[test]
+    fn click_on_task_row_moves_cursor_there() {
+        let mut app = build_app_for_mouse();
+        render_for_mouse_test(&app);
+        assert_eq!(app.cursor, 0);
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 3, 4),
+        );
+
+        assert_eq!(app.cursor, 2);
+    }
+
+    #[test]
+    fn click_above_the_list_body_is_ignored() {
+        let mut app = build_app_for_mouse();
+        app.cursor = 1;
+        render_for_mouse_test(&app);
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 3, 0),
+        );
+
+        assert_eq!(
+            app.cursor, 1,
+            "clicking the header must not move the cursor"
+        );
+    }
+
+    #[test]
+    fn click_is_ignored_outside_normal_and_visual_modes() {
+        let mut app = build_app_for_mouse();
+        render_for_mouse_test(&app);
+        app.mode = Mode::Insert;
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 3, 4),
+        );
+
+        assert_eq!(
+            app.cursor, 0,
+            "a click behind an open overlay must not move the cursor underneath it"
+        );
+    }
+
+    #[test]
+    fn scroll_wheel_moves_cursor_like_j_and_k() {
+        let mut app = build_app_for_mouse();
+        render_for_mouse_test(&app);
+        assert_eq!(app.cursor, 0);
+
+        handle_mouse(&mut app, mouse(MouseEventKind::ScrollDown, 3, 4));
+        assert_eq!(app.cursor, 1);
+
+        handle_mouse(&mut app, mouse(MouseEventKind::ScrollDown, 3, 4));
+        assert_eq!(app.cursor, 2);
+
+        handle_mouse(&mut app, mouse(MouseEventKind::ScrollUp, 3, 4));
+        assert_eq!(app.cursor, 1);
+    }
+
+    #[test]
+    fn scroll_wheel_clamps_at_list_bounds() {
+        let mut app = build_app_for_mouse();
+        render_for_mouse_test(&app);
+
+        handle_mouse(&mut app, mouse(MouseEventKind::ScrollUp, 3, 4));
+        assert_eq!(app.cursor, 0, "must not go negative");
+
+        app.cursor = 2;
+        handle_mouse(&mut app, mouse(MouseEventKind::ScrollDown, 3, 4));
+        assert_eq!(app.cursor, 2, "must not scroll past the last task");
+    }
+
+    fn build_app_with_raw(raw: &str) -> App {
+        let path = std::env::temp_dir().join(format!(
+            "tuxedo-bindings-{}-{:?}.txt",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::write(&path, raw);
+        App::new(path, raw.into(), "2026-05-07".into(), Config::default())
+    }
+
+    fn build_app_for_filters_mouse() -> App {
+        let mut app = build_app_with_raw("buy milk +home\ncall bob +work @phone\n");
+        app.prefs.layout.left = true;
+        app.prefs.layout.right = false;
+        app
+    }
+
+    fn render_filters_test(app: &App) {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).expect("test backend");
+        terminal
+            .draw(|f| ui::draw(f, app))
+            .expect("render for filters mouse test");
+    }
+
+    #[test]
+    fn click_project_row_applies_filter_click_again_clears_it() {
+        let mut app = build_app_for_filters_mouse();
+        render_filters_test(&app);
+
+        // Sidebar rows: 0 filters, 1 blank, 2 projects, 3 home, 4 work,
+        // 5 blank, 6 contxt, 7 phone.
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 5, 3),
+        );
+        assert_eq!(app.filter().project.as_deref(), Some("home"));
+
+        render_filters_test(&app);
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 5, 3),
+        );
+        assert_eq!(
+            app.filter().project,
+            None,
+            "clicking the active project row again must clear the filter"
+        );
+    }
+
+    #[test]
+    fn click_context_row_applies_filter() {
+        let mut app = build_app_for_filters_mouse();
+        render_filters_test(&app);
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 5, 7),
+        );
+        assert_eq!(app.filter().context.as_deref(), Some("phone"));
+    }
+
+    #[test]
+    fn click_sidebar_header_row_does_nothing() {
+        let mut app = build_app_for_filters_mouse();
+        render_filters_test(&app);
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 5, 2),
+        );
+        assert_eq!(app.filter().project, None);
+        assert_eq!(app.filter().context, None);
+    }
+
+    fn build_app_for_detail_mouse() -> App {
+        let mut app = build_app_with_raw("call bob +work @phone\n");
+        app.prefs.layout.left = false;
+        app.prefs.layout.right = true;
+        app
+    }
+
+    fn render_detail_test(app: &App) {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).expect("test backend");
+        terminal
+            .draw(|f| ui::draw(f, app))
+            .expect("render for detail mouse test");
+    }
+
+    #[test]
+    fn click_project_token_in_detail_pane_applies_filter() {
+        let mut app = build_app_for_detail_mouse();
+        render_detail_test(&app);
+
+        let rect = app.detail_rect();
+        handle_mouse(
+            &mut app,
+            mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                rect.x + 12,
+                rect.y + 4,
+            ),
+        );
+        assert_eq!(app.filter().project.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn click_context_token_in_detail_pane_applies_filter() {
+        let mut app = build_app_for_detail_mouse();
+        render_detail_test(&app);
+
+        let rect = app.detail_rect();
+        handle_mouse(
+            &mut app,
+            mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                rect.x + 12,
+                rect.y + 5,
+            ),
+        );
+        assert_eq!(app.filter().context.as_deref(), Some("phone"));
+    }
+
+    #[test]
+    fn click_between_detail_tokens_does_nothing() {
+        let mut app = build_app_for_detail_mouse();
+        render_detail_test(&app);
+
+        let rect = app.detail_rect();
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), rect.x, rect.y + 4),
+        );
+        assert_eq!(app.filter().project, None);
+    }
+
+    #[test]
+    fn repro_stale_filters_rect_after_hiding_left_pane() {
+        let mut app = build_app_for_filters_mouse();
+        render_filters_test(&app);
+        assert_eq!(app.filter().project, None);
+
+        app.prefs.layout.left = false;
+        render_filters_test(&app);
+
+        handle_mouse(
+            &mut app,
+            mouse(MouseEventKind::Down(MouseButton::Left), 5, 3),
+        );
+        assert_eq!(
+            app.filter().project,
+            None,
+            "clicking where the sidebar used to be, after it was hidden, must not apply a stale filter"
+        );
     }
 }

--- a/src/ui/archive.rs
+++ b/src/ui/archive.rs
@@ -31,12 +31,15 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         },
     );
 
+    app.view_body_rect[View::Archive.idx()].set(body_area);
+
     let visible = app.visible_indices();
     let groups = app.visible_groups();
     let blank = super::density_blank_lines(app.prefs.density);
     let cursor_active = app.mode != Mode::Help && app.mode != Mode::Settings;
 
     if visible.is_empty() {
+        app.view_row_index[View::Archive.idx()].replace(Vec::new());
         let para = Paragraph::new(vec![Line::from(Span::styled(
             "   no completed tasks yet".to_string(),
             Style::default().fg(theme.dim),
@@ -57,6 +60,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let mut lines: Vec<Line> = Vec::new();
     let mut last_date: Option<&str> = None;
     let mut cursor_line: Option<usize> = None;
+    let mut row_index: Vec<(usize, usize)> = Vec::new();
 
     for (i, (&abs, gk)) in visible.iter().zip(groups.iter()).enumerate() {
         let date = match gk {
@@ -102,6 +106,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         if i == app.cursor {
             cursor_line = Some(lines.len());
         }
+        row_index.push((lines.len(), i));
         lines.push(task_row::build_line(task, opts, theme));
     }
 
@@ -113,6 +118,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         lines.len(),
     );
     scroll_cell.set(scroll);
+    app.view_row_index[View::Archive.idx()].replace(row_index);
 
     let para = Paragraph::new(lines)
         .style(Style::default().bg(theme.bg).fg(theme.fg))

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::app::App;
+use crate::app::{App, FilterTarget};
 use crate::theme::Theme;
 use crate::todo::Task;
 use crate::ui::task_row::{due_label, due_token_style, is_url_token, url_token_style};
@@ -12,23 +12,32 @@ use crate::ui::task_row::{due_label, due_token_style, is_url_token, url_token_st
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let theme = app.theme();
     super::fill_bg(frame, area, Style::default().bg(theme.panel));
+    app.detail_rect.set(area);
 
     let task = app.cur_task();
     // Wrap to the actual pane width minus 1-char left padding and 1-char
     // safety margin on the right. Floor at 16 so a tiny pane still wraps.
     let wrap_w = (area.width as usize).saturating_sub(2).max(16);
-    let lines = build_lines(theme, task, app.today(), wrap_w);
+    let (lines, token_index) = build_lines(theme, task, app.today(), wrap_w);
+    app.detail_token_index.replace(token_index);
     let para = Paragraph::new(lines).style(Style::default().bg(theme.panel).fg(theme.fg));
     frame.render_widget(para, area);
 }
+
+/// `(line, col_start, col_end, target)` per `+project`/`@context` token,
+/// alongside the lines built. Kept as a return value (not written straight
+/// into `App`) so this stays a pure function the way it was before mouse
+/// support existed.
+type TokenIndex = Vec<(usize, u16, u16, FilterTarget)>;
 
 fn build_lines<'a>(
     theme: &Theme,
     task: Option<&'a Task>,
     today: &'a str,
     wrap_w: usize,
-) -> Vec<Line<'a>> {
+) -> (Vec<Line<'a>>, TokenIndex) {
     let mut rows: Vec<Line> = Vec::new();
+    let mut tokens: TokenIndex = Vec::new();
     rows.push(line_panel(
         theme,
         vec![Span::styled(
@@ -42,7 +51,7 @@ fn build_lines<'a>(
             theme,
             vec![Span::styled(" (no task)", Style::default().fg(theme.dim))],
         ));
-        return rows;
+        return (rows, tokens);
     };
 
     let priority_value = if let Some(p) = t.priority {
@@ -83,33 +92,25 @@ fn build_lines<'a>(
             ],
         ));
     }
-    rows.push(line_panel(
+    rows.push(token_line(
+        &mut tokens,
+        rows.len(),
         theme,
-        vec![
-            Span::styled(" projects  ", Style::default().fg(theme.dim)),
-            Span::styled(
-                t.projects
-                    .iter()
-                    .map(|p| format!("+{p}"))
-                    .collect::<Vec<_>>()
-                    .join(" "),
-                Style::default().fg(theme.project),
-            ),
-        ],
+        " projects  ",
+        &t.projects,
+        '+',
+        theme.project,
+        FilterTarget::Project,
     ));
-    rows.push(line_panel(
+    rows.push(token_line(
+        &mut tokens,
+        rows.len(),
         theme,
-        vec![
-            Span::styled(" contexts  ", Style::default().fg(theme.dim)),
-            Span::styled(
-                t.contexts
-                    .iter()
-                    .map(|c| format!("@{c}"))
-                    .collect::<Vec<_>>()
-                    .join(" "),
-                Style::default().fg(theme.context),
-            ),
-        ],
+        " contexts  ",
+        &t.contexts,
+        '@',
+        theme.context,
+        FilterTarget::Context,
     ));
 
     // Rendering notes line by line
@@ -167,7 +168,37 @@ fn build_lines<'a>(
         }
         rows.push(line_panel(theme, spans));
     }
-    rows
+    (rows, tokens)
+}
+
+
+#[allow(clippy::too_many_arguments)]
+fn token_line<'a>(
+    tokens: &mut TokenIndex,
+    line: usize,
+    theme: &Theme,
+    label: &'static str,
+    values: &'a [String],
+    sigil: char,
+    color: ratatui::style::Color,
+    target: impl Fn(String) -> FilterTarget,
+) -> Line<'a> {
+    let label_span = Span::styled(label, Style::default().fg(theme.dim));
+    let mut col: u16 = label_span.width() as u16;
+    let mut spans = vec![label_span];
+    for (i, value) in values.iter().enumerate() {
+        if i > 0 {
+            let sep = Span::raw(" ");
+            col += sep.width() as u16;
+            spans.push(sep);
+        }
+        let token = Span::styled(format!("{sigil}{value}"), Style::default().fg(color));
+        let width = token.width() as u16;
+        tokens.push((line, col, col + width, target(value.clone())));
+        col += width;
+        spans.push(token);
+    }
+    line_panel(theme, spans)
 }
 
 #[derive(Default)]

--- a/src/ui/filters.rs
+++ b/src/ui/filters.rs
@@ -4,18 +4,20 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::app::{App, Filter, ordered_unique};
+use crate::app::{App, Filter, FilterTarget, ordered_unique};
 use crate::core::filter;
 use crate::theme::Theme;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let theme = app.theme();
     super::fill_bg(frame, area, Style::default().bg(theme.panel));
+    app.filters_rect.set(area);
 
     let projects = ordered_unique(app.tasks(), |t| &t.projects);
     let contexts = ordered_unique(app.tasks(), |t| &t.contexts);
 
     let mut lines: Vec<Line> = Vec::new();
+    let mut row_index: Vec<(usize, FilterTarget)> = Vec::new();
     lines.push(line_pad(
         theme,
         vec![Span::styled(
@@ -38,6 +40,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         for (name, count) in &projects {
             let active = app.filter.project.as_deref() == Some(name.as_str());
+            row_index.push((lines.len(), FilterTarget::Project(name.clone())));
             lines.push(filter_row(theme, "+", name, *count, active, theme.project));
         }
     }
@@ -56,6 +59,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         for (name, count) in &contexts {
             let active = app.filter.context.as_deref() == Some(name.as_str());
+            row_index.push((lines.len(), FilterTarget::Context(name.clone())));
             lines.push(filter_row(theme, "@", name, *count, active, theme.context));
         }
     }
@@ -89,6 +93,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             lines.push(filter_row(theme, "", &f.name, count, active, theme.accent));
         }
     }
+
+    app.filters_row_index.replace(row_index);
 
     let para = Paragraph::new(lines).style(Style::default().bg(theme.panel).fg(theme.fg));
     frame.render_widget(para, area);

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -35,7 +35,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         },
     );
 
+    app.view_body_rect[View::List.idx()].set(body_area);
+
     if app.tasks().is_empty() {
+        app.view_row_index[View::List.idx()].replace(Vec::new());
         crate::ui::empty::render(frame, body_area, app);
         return;
     }
@@ -52,6 +55,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let groups = app.visible_groups();
     let mut lines: Vec<Line> = Vec::new();
     let mut cursor_line: Option<usize> = None;
+    let mut row_index: Vec<(usize, usize)> = Vec::new();
 
     if visible.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -91,6 +95,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             if i == app.cursor {
                 cursor_line = Some(lines.len());
             }
+            row_index.push((lines.len(), i));
             lines.push(task_row::build_line(task, opts, theme));
             if matches!(gk, GroupKey::None) && i != last {
                 for _ in 0..blank {
@@ -108,6 +113,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         lines.len(),
     );
     scroll_cell.set(scroll);
+    app.view_row_index[View::List.idx()].replace(row_index);
 
     let para = Paragraph::new(lines)
         .style(Style::default().bg(theme.bg).fg(theme.fg))

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -85,6 +85,12 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
     if let Some(la) = left_area {
         filters::render(frame, la, app);
+    } else {
+        // Pane hidden this frame: so a click where the
+        // sidebar used to be falls through to the list body
+        // instead of resolving against stale rows.
+        app.filters_rect.set(Rect::default());
+        app.filters_row_index.replace(Vec::new());
     }
     match app.view() {
         View::List => list::render(frame, center_area, app),
@@ -92,6 +98,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
     if let Some(ra) = right_area {
         detail::render(frame, ra, app);
+    } else {
+        app.detail_rect.set(Rect::default());
+        app.detail_token_index.replace(Vec::new());
     }
 
     if app.prefs.layout.status_bar {


### PR DESCRIPTION
Closes #137

  ## What's here

  - Click a task row to move the cursor there
  - Click a `+project`/`@context` in the sidebar filter list, or in the detail pane, to toggle that filter
  - Scroll the wheel to move the cursor up/down, same as `j`/`k`
  - All of the above ignored outside Normal/Visual mode, so a click behind an open overlay (Insert, Help, a picker, the command palette, ...) doesn't silently act on whatever's underneath it

  ## Mouse capture lifecycle

  Mouse capture is enabled on startup and disabled:
  - before handing the terminal to `$EDITOR` (and re-enabled after), so editor clicks arrive as normal input instead of raw escape codes
  - in a panic hook chained in front of `ratatui`'s own, so a panic doesn't leave the terminal spamming mouse escape codes into the shell
  - on normal exit