### PR TITLE
ci: Enforce formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: cargo fmt
-        run: mise run fmt
+      - name: cargo fmt --check
+        run: mise run fmt_check
 
       - name: cargo clippy
         run: mise run clippy

--- a/README.md
+++ b/README.md
@@ -682,8 +682,8 @@ Planned and in-flight work lives in [`todo.txt`](./todo.txt) — eat your own do
 ## Contributing
 
 Issues and pull requests are welcome. For larger changes, please open an
-issue first to discuss the approach. Run `mise run fmt clippy test` (or the
-plain cargo equivalents) before submitting.
+issue first to discuss the approach. Run `mise run preflight` (or the
+plain cargo equivalents described in [Development](#development)) before submitting.
 
 ## License
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+
 [settings]
 lockfile = true
 
@@ -12,7 +14,18 @@ run = "cargo clippy --all-targets --locked -- -D warnings"
 run = "cargo fmt --all"
 
 [tasks.fmt_check]
-run = "cargo fmt --all --check"
+run = { task = "fmt", args = ["--check"] }
+
+[tasks.tuxedo]
+run = "cargo run --bin tuxedo --"
+description = "Run the in-development tuxedo executable. `mise run tuxedo -- <args>` for CLI commands"
+
+[tasks.preflight]
+description = "Prepare and verify changes ready for PR submission"
+run = [ # Run fmt serially first so other tasks won't see files mid-write
+    { task = "fmt" },
+    { tasks = ["clippy", "test"] },
+]
 
 [tasks.test]
 run = "cargo test --locked"


### PR DESCRIPTION
Small fix for not actually checking what we think we are.

We were running the `cargo fmt` task that applies formatting changes on the CI runner, not `--check` to verify code is already compliant.

Also threw in a convenience mise task for `cargo run` when you're in the mise-centric groove, and schema directive for editor assistance if a TOML LS doesn't recognize mise.toml by name.