### PR TITLE
Fix leaky isolation of live config from test harness, config path inject-ability for roundtrip tests

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -355,11 +355,15 @@ impl App {
         self.prefs.sort_label()
     }
 
-    /// Persist preferences. On failure, flashes a short error so the user
-    /// sees the problem inside the TUI (writing to stderr would smash the
-    /// alt-screen).
+    /// Persist preferences to `config_path` when set, else the XDG default.
+    /// On failure, flashes a short error so the user sees the problem inside
+    /// the TUI (writing to stderr would smash the alt-screen).
     pub fn save_prefs(&mut self) {
-        if let Err(e) = self.prefs.save() {
+        let result = match &self.config_path {
+            Some(path) => self.prefs.save_to(path),
+            None => self.prefs.save(),
+        };
+        if let Err(e) = result {
             self.flash(format!("config save failed: {e}"));
         }
     }

--- a/src/app/prefs.rs
+++ b/src/app/prefs.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::path::Path;
 
 use super::types::{Density, Sort};
 use crate::app::WeekStart;
@@ -141,16 +142,16 @@ impl Prefs {
         format!("week_start: {}", self.week_start)
     }
 
-    /// Persist to the XDG config path. Returns the IO error so the caller
-    /// can flash it (writing to stderr from inside the alt-screen would
-    /// corrupt the TUI). Saving is best-effort — callers that don't care
-    /// about reporting can `let _ = prefs.save();`.
+    /// Persist to an explicit config path. Returns the IO error so the
+    /// caller can flash it (writing to stderr from inside the alt-screen
+    /// would corrupt the TUI). Saving is best-effort — callers that don't
+    /// care about reporting can `let _ = prefs.save_to(path);`.
     ///
     /// Loads the on-disk config first so non-pref fields (like
     /// `share_token` / `share_port`, owned by the capture server) are
     /// preserved across pref toggles.
-    pub fn save(&self) -> io::Result<()> {
-        let mut cfg = Config::load();
+    pub fn save_to(&self, path: &Path) -> io::Result<()> {
+        let mut cfg = Config::load_from(path);
         cfg.theme = Some(self.theme().name.to_string());
         cfg.density = Some(self.density);
         cfg.sort = Some(self.sort);
@@ -161,6 +162,13 @@ impl Prefs {
         cfg.show_done = Some(self.show_done);
         cfg.show_future = Some(self.show_future);
         cfg.hidden_keys = self.hidden_keys.clone();
-        cfg.save()
+        cfg.save_to(path)
+    }
+
+    /// Persist to the XDG config path. See [`Prefs::save_to`].
+    pub fn save(&self) -> io::Result<()> {
+        let path = Config::path()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no config dir"))?;
+        self.save_to(&path)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1411,6 +1411,8 @@ fn copy_payload(app: &App, body_only: bool) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use chrono::NaiveDate;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -1435,6 +1437,14 @@ mod tests {
 
     fn task_lines(app: &App) -> Vec<&str> {
         app.tasks().iter().map(|task| task.raw.as_str()).collect()
+    }
+
+    fn mktempcfg(basename: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "tuxedo-{basename}-{}-{:?}.txt",
+            std::process::id(),
+            std::thread::current().id()
+        ))
     }
 
     fn welcome_app(name: &str) -> (App, std::path::PathBuf) {
@@ -1577,26 +1587,23 @@ mod tests {
     }
 
     fn build_app() -> App {
-        let path = std::env::temp_dir().join(format!(
-            "tuxedo-bindings-{}-{:?}.txt",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let path = mktempcfg("bindings");
         let _ = std::fs::write(&path, "a\nb\nc\n");
-        App::new(
+        let mut app = App::new(
             path,
             "a\nb\nc\n".into(),
             "2026-05-07".into(),
             Config::default(),
-        )
+        );
+        // Give saves a scratch destination so tests that exercise a
+        // save_prefs-triggering action (e.g. via handle_settings) never
+        // fall through to the real XDG config path.
+        app.config_path = Some(mktempcfg("config"));
+        app
     }
 
     fn build_app_with_due() -> App {
-        let path = std::env::temp_dir().join(format!(
-            "tuxedo-bindings-{}-{:?}.txt",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let path = mktempcfg("bindings");
         let _ = std::fs::write(&path, "Buy milk due:2026-06-30\n");
         App::new(
             path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1535,6 +1535,28 @@ mod tests {
     }
 
     #[test]
+    fn cycle_prefs_persist_to_config_path() {
+        let path = mktempcfg("prefs-save");
+        let _ = std::fs::remove_file(&path);
+
+        let mut app = build_app();
+        app.config_path = Some(path.clone());
+
+        app.cycle_density();
+        app.cycle_sort();
+        // cycle_theme() also exercised for parity — no dedicated App-level
+        // wrapper test exists for it today either.
+        app.cycle_theme();
+
+        let saved = Config::load_from(&path);
+        assert_eq!(saved.density, Some(app.prefs.density));
+        assert_eq!(saved.sort, Some(app.prefs.sort));
+        assert_eq!(saved.theme.as_deref(), Some(app.theme().name));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn pick_theme_t_cycles_like_j_and_esc_still_cancels() {
         let mut app = build_app();
         app.enter_pick_theme();

--- a/tests/demo-config-path-ignored.sh
+++ b/tests/demo-config-path-ignored.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Demonstrates that App::save_prefs / Prefs::save ignore App.config_path and
+# always resolve Config::path() (XDG) instead — even when a caller has set
+# config_path to point somewhere else entirely (or never set it at all).
+# Safe to run repeatedly: XDG_CONFIG_HOME is redirected to a fresh throwaway
+# dir for the whole subprocess, so the developer's real config is never
+# touched by this script.
+#
+# This script is a standalone, reviewable artifact for the commit that
+# introduces it — check out that commit alone to see the bug reproduced
+# before any fix lands. Safe to drop from history before merging if
+# maintainers don't want to keep it around for regression checks.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+EVIDENCE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tuxedo-config-bug-evidence.XXXXXX")"
+EVIDENCE_CFG="$EVIDENCE_DIR/tuxedo/config.toml"
+echo "== Evidence XDG_CONFIG_HOME: $EVIDENCE_DIR =="
+
+check() {
+  local label="$1"
+  if [ -f "$EVIDENCE_CFG" ]; then
+    echo "  -> config.toml materialized under XDG_CONFIG_HOME ($label):"
+    sed 's/^/     /' "$EVIDENCE_CFG"
+    return 0
+  else
+    echo "  -> no file under XDG_CONFIG_HOME ($label)"
+    return 1
+  fi
+}
+
+echo
+echo "--- Demo 1: tests/snapshots.rs, cycle_sort() scenes ---"
+echo "make_app() sets app.config_path = /tmp/tuxedo-snapshot.toml. If"
+echo "config_path were honored, XDG_CONFIG_HOME should see NOTHING."
+rm -rf "$EVIDENCE_DIR/tuxedo"
+XDG_CONFIG_HOME="$EVIDENCE_DIR" cargo test --test snapshots \
+  > "$EVIDENCE_DIR/snapshots-run.log" 2>&1 || true
+demo1_bug=0
+check "demo 1" && demo1_bug=1
+
+echo
+echo "--- Demo 2: src/main.rs, settings_hinted_keys_apply_and_dialog_stays_open ---"
+echo "build_app() leaves config_path = None entirely."
+rm -rf "$EVIDENCE_DIR/tuxedo"
+XDG_CONFIG_HOME="$EVIDENCE_DIR" cargo test --bin tuxedo \
+  settings_hinted_keys_apply_and_dialog_stays_open \
+  > "$EVIDENCE_DIR/main-run.log" 2>&1 || true
+demo2_bug=0
+check "demo 2" && demo2_bug=1
+
+echo
+echo "== Summary =="
+echo "demo 1 (snapshots cycle_sort ignores config_path): $([ $demo1_bug = 1 ] && echo BUG REPRODUCED || echo not reproduced)"
+echo "demo 2 (main.rs settings test, config_path=None):  $([ $demo2_bug = 1 ] && echo BUG REPRODUCED || echo not reproduced)"
+echo "Logs + evidence retained at: $EVIDENCE_DIR"

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -493,6 +493,7 @@ fn list_scrolls_to_keep_cursor_visible_when_below_fold() {
         "2026-05-06".to_string(),
         Config::default(),
     );
+    app.config_path = Some(PathBuf::from(FIXTURE_CONFIG_PATH));
     app.prefs.density = Density::Compact;
     app.prefs.layout.left = false;
     app.prefs.layout.right = false;


### PR DESCRIPTION
I have fixes ready for [a handful of problems](https://github.com/webstonehq/tuxedo/issues/53#issuecomment-5432537805) with the Sunday/Monday week start switching, but I found that it wasn't possible to write integration tests for the changes with the current test harness. None of the code around preferences saving has test coverage currently, and from what I found that's probably due to some surprising and arguably faulty plumbing in the production code.

This PR fixes issues that led to your personal `~/.config/tuxedo/config.toml` getting clobbered by running the tests in development, despite some code that appeared to avoid that. The solution comes via a light refactoring which also makes injecting the config path possible/safe/correct, for read and write paths, for tests or a possible future `--config` flag, etc.

The first commit is a script that demonstrates the bug because it's difficult to do so by any in-process means. If you check out that commit, inspect and run the script, you can see the verification. It's in a commit by itself so the whole commit can just be dropped from the branch if desired after reviewers have witnessed the reproduction.

The second commit fixes the issues. From there the same script will verify the fix.

The last commit uses this to add a bit of new integration test coverage for preference saving roundtrips. It fails with the fix removed, so is a regression guard.

Refs #129 for underlying root cause, but the actual fix for week-start specifically will come in a subsequent PR.

## Summary

`Config::path()` is the real, resolved `${XDG_CONFIG_HOME:-$HOME/.config}/tuxedo/config.toml`.

`App.config_path` is a field formally documented as essentially a read cache of it, but it's easy to assume that it's authoritative on where writes will go too. It was not.

`App::save_prefs` → `Prefs::save` always resolved `Config::path()` directly, ignoring `config_path`. Tests had no way to redirect *writes* to a controlled destination. Saves *do* happen in tests, so this isn't just about lacking coverage due to a missing capability—it was an active bug: `cargo test` was quietly overwriting your real config on every run.

Snapshot tests set `config_path`, contributing to the false hope that this was isolating. To be fair that is again [documented](https://github.com/webstonehq/tuxedo/blob/744c5207ef38759d0a892475328cdb1ca39be728/tests/snapshots.rs#L40-L44) as serving a read-specific purpose for snapshot hygiene, but it's subtle and this amounts to a footgun.

Code spanning production and tests should reasonably expect that reads and writes agree on the file path that's in use for config. The fix integrates `config_path` into the save path, so that this expectation holds.

This change effectively expands the documented semantics of `App.config_path`, but I'll contend this is for the better.

Finally, now that we have sound test infrastructure for it, preference persistence is given its first test coverage roundtripping through the app layer.

## Test plan

- [x] `cargo test` — full suite green (461 lib + 51 bin + 21 snapshot tests)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `tests/demo-config-path-ignored.sh` run before commit 2: both demos
      report "BUG REPRODUCED"
- [x] Same script run after commit 2: both demos report "not reproduced"
- [x] New test (`cycle_prefs_persist_to_config_path`) confirmed to fail
      without commit 2's fix, confirming it has teeth
- [x] Verified the real `~/.config/tuxedo/config.toml` (backed up beforehand)
      was never touched at any point during this work — checksum identical
      before and after

🤖 Assisted by Claude Code
