### PR TITLE
fix: force TUI redraw after returning from external editor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,7 @@ fn run(
                     handle_key(app, key, keybinds);
                     if let Some(path) = app.take_pending_editor_path() {
                         open_path_in_editor(&path)?;
+                        terminal.clear()?;
                     }
                     dirty = true;
                 }


### PR DESCRIPTION
Editor launches correctly via `o`/`O`, but on exit the alternate screen wasn't being fully repainted — ratatui's internal buffer still reflected the pre-editor state, so the list stayed blank/stale until a navigation event (j/k) triggered a partial re-render.

Call `terminal.clear()` after re-entering the alternate screen so the next draw() forces a full repaint instead of a diff against a stale buffer.

Fixes #99